### PR TITLE
make edoc gen'd from -spec less ugly

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -72,6 +72,9 @@
 -include("riak_pipe.hrl").
 -include("riak_pipe_debug.hrl").
 
+-export_type([fitting/0,
+              fitting_spec/0,
+              exec_opts/0]).
 -type fitting() :: #fitting{}.
 -type fitting_spec() :: #fitting_spec{}.
 -type exec_opts() :: [exec_option()].

--- a/src/riak_pipe_app.erl
+++ b/src/riak_pipe_app.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc Start and stop handling of the =riak_pipe= application.
+%% @doc Start and stop handling of the `riak_pipe' application.
 
 -module(riak_pipe_app).
 

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -57,6 +57,7 @@
 
 -opaque state() :: #state{}.
 
+-export_type([details/0]).
 -type details() :: #fitting_details{}.
 
 %%%===================================================================
@@ -422,7 +423,7 @@ validate_argument(Module, Arg) ->
 %% @doc Validate the parition-choice function.  This must either be
 %%      the atom `follow', or a valid funtion of arity 1 (see {@link
 %%      riak_pipe_v:validate_function/3}).
--spec validate_partfun(follow | riak_pipe:partfun()) ->
+-spec validate_partfun(follow | riak_pipe_vnode:partfun()) ->
          ok | {error, string()}.
 validate_partfun(follow) ->
     ok;

--- a/src/riak_pipe_fitting_sup.erl
+++ b/src/riak_pipe_fitting_sup.erl
@@ -46,7 +46,9 @@ start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 %% @doc Start a new fitting under this supervisor.
--spec add_fitting(pid(), #fitting_spec{}, #fitting{},
+-spec add_fitting(pid(),
+                  riak_pipe:fitting_spec(),
+                  riak_pipe:fitting(),
                   riak_pipe:exec_opts()) ->
          {ok, pid()}.
 add_fitting(Builder, Spec, Output, Options) ->

--- a/src/riak_pipe_log.erl
+++ b/src/riak_pipe_log.erl
@@ -34,7 +34,7 @@
 %%      option was set to `sasl', log messages are printed via
 %%      `error_logger' to the SASL log.  If no option was given, log
 %%      messages are discarded.
--spec log(#fitting_details{}, term()) -> ok.
+-spec log(riak_pipe_fitting:details(), term()) -> ok.
 log(#fitting_details{options=O, name=N}, Msg) ->
     case proplists:get_value(log, O) of
         undefined ->
@@ -58,7 +58,7 @@ log(#fitting_details{options=O, name=N}, Msg) ->
 %%      The `node()' and the name of the fitting will be added to the
 %%      `Types' list - the calling function does not need to specify
 %%      them.
--spec trace(#fitting_details{}, [term()], term()) -> ok.
+-spec trace(riak_pipe_fitting:details(), [term()], term()) -> ok.
 trace(#fitting_details{options=O, name=N}=FD, Types, Msg) ->
     TraceOn = case proplists:get_value(trace, O) of
                   all ->

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -48,6 +48,8 @@
 -include("riak_pipe_log.hrl").
 -include("riak_pipe_debug.hrl").
 
+-export_type([partfun/0,
+              partition/0]). %% from riak_core_vnode.hrl
 -type partfun() :: fun((term()) -> partition()) | follow | sink.
 
 -define(DEFAULT_WORKER_LIMIT, 50).

--- a/src/riak_pipe_vnode_worker_sup.erl
+++ b/src/riak_pipe_vnode_worker_sup.erl
@@ -44,7 +44,7 @@ start_link(Partition, VnodePid) ->
     supervisor:start_link(?MODULE, [Partition, VnodePid]).
 
 %% @doc Start a new worker under the supervisor.
--spec start_worker(pid(), #fitting_details{}) -> {ok, pid()}.
+-spec start_worker(pid(), riak_pipe_fitting:details()) -> {ok, pid()}.
 start_worker(Supervisor, Details) ->
     supervisor:start_child(Supervisor, [Details]).
 

--- a/src/riak_pipe_w_pass.erl
+++ b/src/riak_pipe_w_pass.erl
@@ -33,12 +33,14 @@
 -include("riak_pipe_log.hrl").
 
 -record(state, {p :: riak_pipe_vnode:partition(),
-                fd :: #fitting_details{}}).
+                fd :: riak_pipe_fitting:details()}).
+-opaque state() :: #state{}.
 
 %% @doc Initialization just stows the partition and fitting details in
 %%      the module's state, for sending outputs in {@link process/2}.
--spec init(riak_pipe_vnode:partition(), #fitting_details{}) ->
-        {ok, #state{}}.
+-spec init(riak_pipe_vnode:partition(),
+           riak_pipe_fitting:details()) ->
+        {ok, state()}.
 init(Partition, FittingDetails) ->
     {ok, #state{p=Partition, fd=FittingDetails}}.
 
@@ -47,7 +49,7 @@ init(Partition, FittingDetails) ->
 %%      Input}' before sending the output, and `{processed, Input}' after
 %%      the blocking output send has returned.  This can be useful for
 %%      dropping in another pipeline to watching data move through it.
--spec process(term(), #state{}) -> {ok, #state{}}.
+-spec process(term(), state()) -> {ok, state()}.
 process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     ?T(FittingDetails, [], {processing, Input}),
     riak_pipe_vnode_worker:send_output(Input, Partition, FittingDetails),
@@ -55,6 +57,6 @@ process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     {ok, State}.
 
 %% @doc Unused.
--spec done(#state{}) -> ok.
+-spec done(state()) -> ok.
 done(_State) ->
     ok.

--- a/src/riak_pipe_w_tee.erl
+++ b/src/riak_pipe_w_tee.erl
@@ -36,18 +36,19 @@
 -include("riak_pipe_log.hrl").
 
 -record(state, {p :: riak_pipe_vnode:partition(),
-                fd :: #fitting_details{}}).
+                fd :: riak_pipe_fitting:details()}).
+-opaque state() :: #state{}.
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
--spec init(riak_pipe_vnode:partition(), #fitting_details{}) ->
-         {ok, #state{}}.
+-spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->
+         {ok, state()}.
 init(Partition, FittingDetails) ->
     {ok, #state{p=Partition, fd=FittingDetails}}.
 
 %% @doc Processing an input involves sending it to both the fitting
 %%      specified by the argument (possibly the sink), and to the
 %%      output.
--spec process(term(), #state{}) -> {ok, #state{}}.
+-spec process(term(), state()) -> {ok, state()}.
 process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     Tee = case FittingDetails#fitting_details.arg of
               sink ->
@@ -61,7 +62,7 @@ process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     {ok, State}.
 
 %% @doc Unused.
--spec done(#state{}) -> ok.
+-spec done(state()) -> ok.
 done(_State) ->
     ok.
 

--- a/src/riak_pipe_w_xform.erl
+++ b/src/riak_pipe_w_xform.erl
@@ -52,16 +52,17 @@
 -include("riak_pipe.hrl").
 
 -record(state, {p :: riak_pipe_vnode:partition(),
-                fd :: #fitting_details{}}).
+                fd :: riak_pipe_fitting:details()}).
+-opaque state() :: #state{}.
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
--spec init(riak_pipe_vnode:partition(), #fitting_details{}) ->
-         {ok, #state{}}.
+-spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->
+         {ok, state()}.
 init(Partition, FittingDetails) ->
     {ok, #state{p=Partition, fd=FittingDetails}}.
 
 %% @doc Process evaluates the fitting's argument function.
--spec process(term(), #state{}) -> {ok, #state{}}.
+-spec process(term(), state()) -> {ok, state()}.
 process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     Fun = FittingDetails#fitting_details.arg,
     try
@@ -75,7 +76,7 @@ process(Input, #state{p=Partition, fd=FittingDetails}=State) ->
     {ok, State}.
 
 %% @doc Unused.
--spec done(#state{}) -> ok.
+-spec done(state()) -> ok.
 done(_State) ->
     ok.
 


### PR DESCRIPTION
My attempt to get rid of some of the noise generated by edoc using -spec to fill in function type information.  Do we like this?  Is there a better way?  Does this harm dialyzer analysis at all?
