### PR TITLE
Clean up & pay attention to reference usage

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -180,7 +180,13 @@ ensure_sink(Options) ->
                                  _ ->
                                      Sink
                              end,
-                    {PFSink, lists:keyreplace(sink, 1, Options, PFSink)};
+                    RPFSink = case PFSink#fitting.ref of
+                                  undefined ->
+                                      PFSink#fitting{ref=make_ref()};
+                                  _ ->
+                                      PFSink
+                              end,
+                    {RPFSink, lists:keyreplace(sink, 1, Options, RPFSink)};
                true ->
                     throw({invalid_sink, nopid})
             end;

--- a/src/riak_pipe_builder_sup.erl
+++ b/src/riak_pipe_builder_sup.erl
@@ -52,7 +52,7 @@ start_link() ->
 %% @doc Start a new pipeline builder.  Starts the builder process
 %%      under this supervisor.
 -spec new_pipeline([#fitting_spec{}], riak_pipe:exec_opts()) ->
-         {ok, pid()}.
+         {ok, pid(), riak_pipe_builder:builder()}.
 new_pipeline(Spec, Options) ->
     supervisor:start_child(?MODULE, [Spec, Options]).
 


### PR DESCRIPTION
All fittings include a reference() in addition to a pid().  The thought was that Pipe will start and stop lots of processes, so a reference was included to fight against accidents caused by pid reuse.

This changeset makes sure that those references are checked, to actually fulfill their purpose.

This changeset also attempts to simplify things by using the same reference for the entire pipeline, instead of generating new refs in each fitting.
