### PR TITLE
Simplify the "builder" stuff

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,7 +76,7 @@ starting these fitting processes.  It begins by starting a "builder"
 process, which then starts and monitors each of the fitting processes,
 starting with the final one (so that its =pid= can be passed to its
 predecessor).  When all of the fitting processes have started, the
-=pid= of the first is sent to the client.
+=pid= of the first is returned to the client.
 
 ** Send inputs
 
@@ -218,11 +218,10 @@ the pipeline as a whole.  Currently supported options are:
             one of their types matches one of the types listed.  If
             left undefined, all trace messages are ignored silently.
 
-The =riak_pipe:exec/2= function will return a tuple of the form
-={ok, Builder, Sink}=.  To get the head fitting of the pipeline,
-immediately call =riak_pipe:wait_first_fitting(Builder)=.  The
-=wait_first_fitting/1= function will return a tuple of the form
-={ok, HeadFitting}=.
+The =riak_pipe:exec/2= function will return a tuple of the form ={ok,
+Head, Sink}=, =Head= being the tag you'll use to send inputs into the
+start of the pipeline, and =Sink= being details about where output is
+sent.
 
 *** Sending inputs
 
@@ -230,7 +229,6 @@ Once you have the first fitting, you can send inputs to it using
 =riak_pipe_vnode:queue_work/2=:
 
 #+BEGIN_SRC erlang
-{ok, Head} = riak_pipe:wait_first_fitting(Builder),
 riak_pipe_vnode:queue_work(Head, "please process this list").
 #+END_SRC
 

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -29,15 +29,11 @@
 
 %% API
 -export([start_link/2]).
--export([fitting_started/2,
-         fitting_pids/1,
+-export([fitting_pids/1,
          get_first_fitting/1]).
 
 %% gen_fsm callbacks
 -export([init/1,
-         start_first_fitting/2,
-         wait_fitting_start/2,
-         wait_fitting_start/3,
          wait_pipeline_shutdown/2,
          wait_pipeline_shutdown/3,
          handle_event/3,
@@ -52,9 +48,7 @@
 -export_type([builder/0]).
 -record(state, {options :: riak_pipe:exec_opts(),
                 ref :: reference(),
-                unstarted :: [#fitting_spec{}],
-                alive :: [{#fitting{}, reference()}], % monitor ref
-                waiting :: [term()]}). % gen_fsm From reply handles
+                alive :: [{#fitting{}, reference()}]}). % monitor ref
 
 -opaque state() :: #state{}.
 -opaque builder() :: {pid(), reference()}.
@@ -75,17 +69,10 @@ start_link(Spec, Options) ->
             Error
     end.
 
-%% @doc Notify the `Builder' that the fitting has completed its
-%%      startup and is described by `Fitting'.  The value of `Fitting'
-%%      is what will be used to tag inputs to vnode queues.
--spec fitting_started(pid(), riak_pipe:fitting()) -> ok.
-fitting_started(Builder, Fitting) ->
-    gen_fsm:send_event(Builder, {fitting_started, Fitting}).
-
 %% @doc Get the list of pids for fittings that this builder started.
 %%      If the builder terminated before this call was made, the
 %%      function returns the atom `gone'.
--spec fitting_pids(pid()) -> {ok, {integer(), [pid()]}} | gone.
+-spec fitting_pids(pid()) -> {ok, FittingPids::[pid()]} | gone.
 fitting_pids(Builder) ->
     try
         {ok, gen_fsm:sync_send_all_state_event(Builder, fittings)}
@@ -106,54 +93,14 @@ get_first_fitting({BuilderPid, Ref}) ->
 
 %% @doc Initialize the builder fsm (gen_fsm callback).
 -spec init([ [riak_pipe:fitting_spec()] | riak_pipe:exec_opts() ]) ->
-         {ok, start_first_fitting, state(), 0}.
+         {ok, wait_pipeline_shutdown, state()}.
 init([Spec, Options]) ->
     {sink, #fitting{ref=Ref}} = lists:keyfind(sink, 1, Options),
-    {ok, start_first_fitting,
-     #state{unstarted=lists:reverse(Spec),
-            options=Options,
+    Fittings = start_fittings(Spec, Options),
+    {ok, wait_pipeline_shutdown,
+     #state{options=Options,
             ref=Ref,
-            alive=[],
-            waiting=[]},
-     0}.
-
-%% @doc Start the tail fitting (gen_fsm callback).  The "first" in the
-%%      name comes from the fact that the "tail" fitting is started
-%%      first, so its handle can be passed to its predecessor. (TODO)
--spec start_first_fitting(timeout, state()) ->
-         {next_state, wait_fitting_start, state()}.
-start_first_fitting(timeout, #state{unstarted=[Last|Rest]}=State) ->
-    ClientOutput = client_output(State#state.options),
-    start_fitting(Last,
-                  ClientOutput,
-                  State#state.options),
-    {next_state, wait_fitting_start, State#state{unstarted=Rest}}.
-
-%% @doc The builder asked the fitting supervisor to start a new
-%%      fitting, and is now waiting for confirmation that that fitting
-%%      started successfully.  When it receives that confirmation, it
-%%      will start the next fitting up the pipe, or go into a wait
-%%      state pending pipeline shutdown.  Before going into that wait
-%%      state, the head fitting is sent to any clients that asked for it.
--spec wait_fitting_start({fitting_started, riak_pipe:fitting()}, state()) ->
-         {next_state, wait_fitting_start | wait_pipeline_shutdown, state()}.
-wait_fitting_start({fitting_started, Fitting},
-                   #state{alive=Alive}=State) ->
-    Ref = erlang:monitor(process, Fitting#fitting.pid),
-    AliveState = State#state{alive=[{Fitting,Ref}|Alive]},
-    case AliveState#state.unstarted of
-        [] ->
-            %% toss the first fitting to anyone wanting it
-            announce_first_fitting(Fitting, AliveState#state.waiting),
-            {next_state, wait_pipeline_shutdown,
-             AliveState#state{waiting=[]}};
-        [Next|Rest] ->
-            start_fitting(Next,
-                          Fitting,
-                          AliveState#state.options),
-            {next_state, wait_fitting_start,
-             AliveState#state{unstarted=Rest}}
-    end.
+            alive=Fittings}}.
 
 %% @doc All fittings have been started, and the builder is just
 %%      monitoring the pipeline (and replying to clients looking
@@ -162,21 +109,6 @@ wait_fitting_start({fitting_started, Fitting},
          {next_state, wait_pipeline_shutdown, state()}.
 wait_pipeline_shutdown(_Event, State) ->
     {next_state, wait_pipeline_shutdown, State}.
-
-%% @doc A client is asking for the head fitting, but that fitting
-%%      hasn't started yet.  Delay response for later.
--spec wait_fitting_start({get_first_fitting, reference()},
-                         term(), state()) ->
-         {next_state, wait_fitting_start, state()}.
-wait_fitting_start({get_first_fitting, Ref}, From,
-                   #state{ref=Ref, waiting=Waiting}=State) ->
-            %% something still unstarted
-            %% reply once everything else is up
-    {next_state, wait_fitting_start,
-     State#state{waiting=[From|Waiting]}};
-wait_fitting_start(_, _, State) ->
-    %% unknown message - reply {error, unknown} to get rid of it
-    {reply, {error, unknown}, wait_fitting_start, State}.
 
 %% @doc A client is asking for the head fitting.  Respond.
 -spec wait_pipeline_shutdown({get_first_fitting, reference()},
@@ -205,13 +137,12 @@ handle_event(_Event, StateName, State) ->
 %%      and pids for fittings already started.
 -spec handle_sync_event(fittings, term(), atom(), state()) ->
          {reply,
-          {UnstartedCount::integer(), FittingPids::[pid()]},
+          FittingPids::[pid()],
           StateName::atom(),
           state()}.
 handle_sync_event(fittings, _From, StateName,
-                  #state{unstarted=Unstarted, alive=Alive}=State) ->
-    Reply = {length(Unstarted),
-             [ Pid || {#fitting{pid=Pid},_Ref} <- Alive ]},
+                  #state{alive=Alive}=State) ->
+    Reply = [ Pid || {#fitting{pid=Pid},_Ref} <- Alive ],
     {reply, Reply, StateName, State};
 handle_sync_event(_Event, _From, StateName, State) ->
     Reply = ok,
@@ -277,26 +208,35 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
+
+%% @doc Start and monitor all of the fittings for this builder's
+%%      pipeline.
+-spec start_fittings([riak_pipe:fitting_spec()],
+                     riak_pipe:exec_opts()) ->
+           [{riak_pipe:fitting(), reference()}].
+start_fittings(Spec, Options) ->
+    [Tail|Rest] = lists:reverse(Spec),
+    ClientOutput = client_output(Options),
+    lists:foldl(fun(FitSpec, [{Output,_}|_]=Acc) ->
+                        [start_fitting(FitSpec, Output, Options)|Acc]
+                end,
+                [start_fitting(Tail, ClientOutput, Options)],
+                Rest).
+
 %% @doc Start a new fitting, as specified by `Spec', sending its
 %%      output to `Output'.
 -spec start_fitting(riak_pipe:fitting_spec(),
                     riak_pipe:fitting(),
                     riak_pipe:exec_opts()) ->
-         {ok, pid()}.
+         {riak_pipe:fitting(), reference()}.
 start_fitting(Spec, Output, Options) ->
     ?DPF("Starting fitting for ~p", [Spec]),
-    riak_pipe_fitting_sup:add_fitting(
-      self(), Spec, Output, Options).
+    {ok, Pid, Fitting} = riak_pipe_fitting_sup:add_fitting(
+                           self(), Spec, Output, Options),
+    Ref = erlang:monitor(process, Pid),
+    {Fitting, Ref}.
 
 %% @doc Find the sink in the options passed.
 -spec client_output(riak_pipe:exec_opts()) -> riak_pipe:fitting().
 client_output(Options) ->
     proplists:get_value(sink, Options).
-
-%% @doc Reply to all waiting requests for the head fitting.
-%%      `Waiting' is a list of the "`From'" parameters that gen_fsm
-%%      passed to the sync event handlers.
--spec announce_first_fitting(riak_pipe:fitting(), [term()]) -> ok.
-announce_first_fitting(Fitting, Waiting) ->
-    [ gen_fsm:reply(W, {ok, Fitting}) || W <- Waiting ],
-    ok.

--- a/src/riak_pipe_builder_sup.erl
+++ b/src/riak_pipe_builder_sup.erl
@@ -52,9 +52,14 @@ start_link() ->
 %% @doc Start a new pipeline builder.  Starts the builder process
 %%      under this supervisor.
 -spec new_pipeline([#fitting_spec{}], riak_pipe:exec_opts()) ->
-         {ok, pid(), riak_pipe_builder:builder()}.
+         {ok, Head::#fitting{}} | {error, Reason::term()}.
 new_pipeline(Spec, Options) ->
-    supervisor:start_child(?MODULE, [Spec, Options]).
+    case supervisor:start_child(?MODULE, [Spec, Options]) of
+        {ok, Pid, Ref} ->
+            riak_pipe_builder:get_first_fitting(Pid, Ref);
+        Error ->
+            Error
+    end.
 
 %% @doc Get information about the builders supervised here.
 -spec builder_pids() -> [{term(),

--- a/src/riak_pipe_cinfo.erl
+++ b/src/riak_pipe_cinfo.erl
@@ -55,9 +55,9 @@ pipelines(C) ->
 -spec pipeline(ClusterInfoHandle::term(), Builder::pid()) -> ok.
 pipeline(C, Pipe) ->
     case riak_pipe_builder:fitting_pids(Pipe) of
-        {ok, {UnstartedCount, Fits}} ->
-            cluster_info:format(C, " - ~p fittings: ~b unstarted, ~b alive~n",
-                                [Pipe, UnstartedCount, length(Fits)]),
+        {ok, Fits} ->
+            cluster_info:format(C, " - ~p fittings: ~b alive~n",
+                                [Pipe, length(Fits)]),
             [ fitting(C, Fit) || Fit <- Fits ];
         gone ->
             cluster_info:format(C, " - ~p *gone*~n", [Pipe])

--- a/src/riak_pipe_fitting_sup.erl
+++ b/src/riak_pipe_fitting_sup.erl
@@ -50,7 +50,7 @@ start_link() ->
                   riak_pipe:fitting_spec(),
                   riak_pipe:fitting(),
                   riak_pipe:exec_opts()) ->
-         {ok, pid()}.
+         {ok, pid(), riak_pipe:fitting()}.
 add_fitting(Builder, Spec, Output, Options) ->
     ?DPF("Adding fitting for ~p", [Spec]),
     supervisor:start_child(?SERVER, [Builder, Spec, Output, Options]).


### PR DESCRIPTION
This PR encapsulates two changes:
1. Starting and monitoring all fittings from `riak_pipe_builder:init/1`.  This simplifies the interaction between the builder and the fittings quite a bit, while seeming to have no other adverse effects.
2. Pushing the ask-the-builder-for-the-first-fitting step down below the level of client API.  This removes the need for `riak_pipe:wait_first_fitting/1` by having `riak_pipe:exec/2` return {ok, Head, Sink} instead of {ok, Builder, Sink}.

If you're testing with `riak_kv_mrc_pipe`, you'll need to checkout the `pipe-bwf-builder` branch from https://github.com/beerriot/riak_kv
