### PR TITLE
monitor the vnode in case it fails before replying to 'queue_work'

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -1197,6 +1197,22 @@ exception_test_() ->
                        %% consistent hash means this should be the same
                        ?assertEqual(Requeuer, Forward)
                end}
+      end,
+      fun(_) ->
+              {"Vnode Death",
+               fun() ->
+                       {ok, Head, Sink} =
+                           riak_pipe:exec(
+                             [#fitting_spec{name=vnode_death_test,
+                                            module=riak_pipe_w_crash}],
+                             []),
+                       %% this should kill vnode such that it never
+                       %% responds to the enqueue request
+                       riak_pipe_vnode:queue_work(Head, vnode_killer),
+                       riak_pipe_fitting:eoi(Head),
+                       {eoi, Res, []} = riak_pipe:collect_results(Sink),
+                       ?assertEqual([], Res)
+               end}
       end
      ]
     }.

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -574,6 +574,12 @@ enqueue_internal(#cmd_enqueue{fitting=Fitting, input=Input, timeout=TO,
                               usedpreflist=UsedPreflist},
                  Sender, #state{partition=Partition}=State) ->
     case worker_for(Fitting, State) of
+        {ok, #worker{details=#fitting_details{module=riak_pipe_w_crash}}}
+          when Input == vnode_killer ->
+            %% this is used by the eunit test named "Vnode Death"
+            %% in riak_pipe:exception_test_; it kills the vnode before
+            %% it has a chance to reply to the queue request
+            exit({riak_pipe_w_crash, vnode_killer});
         {ok, Worker} when (Worker#worker.details)#fitting_details.module
                           /= ?FORWARD_WORKER_MODULE ->
             case add_input(Worker, Input, Sender, TO, UsedPreflist) of


### PR DESCRIPTION
If a vnode died after being sent a request to queue work, the receive clause in `riak_pipe_vnode:queue_work_send/4` would hang forever.  This patch set includes a test to prove that, as well as a proposed fix: essentially, monitoring the vnode and watching for a 'DOWN' message.

The main problem is that testing seems to show that this makes queue_work_send take much longer.  The slowdown seems to come not from setting up and tearing down monitors, but from waiting for the vnode master to respond with the vnode's pid.  Can anyone else confirm and/or come up with a better idea?
