### PR TITLE
move all client interaction to the riak_pipe module

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,8 +76,8 @@ the partition choice function for distributing that fitting's inputs.
 starting these fitting processes.  It begins by starting a "builder"
 process, which then starts and monitors each of the fitting processes,
 starting with the final one (so that its =pid= can be passed to its
-predecessor).  When all of the fitting processes have started, the
-=pid= of the first is returned to the client.
+predecessor).  When all of the fitting processes have started, a
+structure capturing their details is return to the client.
 
 ** Send inputs
 
@@ -226,30 +226,31 @@ the pipeline as a whole.  Currently supported options are:
             left undefined, all trace messages are ignored silently.
 
 The =riak_pipe:exec/2= function will return a tuple of the form ={ok,
-Head, Sink}=, =Head= being the tag you'll use to send inputs into the
-start of the pipeline, and =Sink= being details about where output is
-sent.
+Pipe}=, =Pipe= being a handle to the pipeline that was created (in the
+form of a =pipe= record, as defined in =include/riak_pipe.hrl=), which
+you will use to send inputs, to indicate the end of inputs, and to
+receive outputs later.
 
 *** Sending inputs
 
-Once you have the first fitting, you can send inputs to it using
-=riak_pipe_vnode:queue_work/2=:
+Once you have the pipe handle, you can send inputs to it using
+=riak_pipe:queue_work/2=:
 
 #+BEGIN_SRC erlang
-riak_pipe_vnode:queue_work(Head, "please process this list").
+riak_pipe:queue_work(Pipe, "please process this list").
 #+END_SRC
 
-The =queue_work/2= function evaluates the =chashfun= function (from the
-fitting's specification) against =Input=, and then sends =Input= to
-the vnode owning the range in which the hash falls.
+The =queue_work/2= function evaluates the =chashfun= function (from
+the first fitting's specification) against =Input=, and then sends
+=Input= to the vnode owning the range in which the hash falls.
 
 *** Sending eoi
 
-When you have sent all the inputs you want to the pipeline, tell the
-head fitting that you're done with =riak_pipe_fitting:eoi/1=:
+When you have sent all the inputs you want to the pipeline, tell it
+that you're done with =riak_pipe:eoi/1=:
 
 #+BEGIN_SRC erlang
-riak_pipe_fitting:eoi(Head)
+riak_pipe:eoi(Pipe)
 #+END_SRC
 
 This allows the fitting to begin shutting down its workers.  When all
@@ -293,21 +294,21 @@ If you'd rather receive the entire result set at once, instead of
 streamed, you can use the =riak_pipe:collect_results/1= function:
 
 #+BEGIN_SRC erlang
-{ok, Results, LogMessages} = riak_pipe:collect_results(Sink).
+{ok, Results, LogMessages} = riak_pipe:collect_results(Pipe).
 #+END_SRC
 
 The =receive_result/1= function is also exported from =riak_pipe= to
 make it easy to wait for the next piece of output:
 
 #+BEGIN_SRC erlang
-consume(Fitting) ->
-   case riak_pipe:receive_result(Fitting) of
+consume(Pipe) ->
+   case riak_pipe:receive_result(Pipe) of
       {result, {From, Result}} ->
          io:format("Received ~p from ~p!~n", [Result, From]),
-         consume(Fitting);
+         consume(Pipe);
       {log, {From, Msg}} ->
          io:format("Logged ~p from ~p!~n", [Msg, From]),
-         consume(Fitting);
+         consume(Pipe);
       eoi ->
          io:format("Done!~n")
    end.

--- a/include/riak_pipe.hrl
+++ b/include/riak_pipe.hrl
@@ -25,6 +25,13 @@
           nval = 1 :: riak_pipe_vnode:nval()
         }).
 
+-record(pipe,
+        {
+          builder :: pid(),
+          fittings :: [#fitting{}],
+          sink :: #fitting{}
+        }).
+
 -record(pipe_result,
         {
           ref,

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -81,7 +81,7 @@ fitting_pids(Builder) ->
 %% @doc Get the `#fitting{}' records describing the fittings in
 %%      this builder's pipeline.  This function will block until the
 %%      builder has finished building the pipeline.
--spec get_fittings(pid(), reference()) -> {ok, riak_pipe:fitting()}.
+-spec get_fittings(pid(), reference()) -> {ok, [riak_pipe:fitting()]}.
 get_fittings(BuilderPid, Ref) ->
     gen_fsm:sync_send_event(BuilderPid, {get_fittings, Ref}).
 

--- a/src/riak_pipe_builder_sup.erl
+++ b/src/riak_pipe_builder_sup.erl
@@ -52,11 +52,13 @@ start_link() ->
 %% @doc Start a new pipeline builder.  Starts the builder process
 %%      under this supervisor.
 -spec new_pipeline([#fitting_spec{}], riak_pipe:exec_opts()) ->
-         {ok, Head::#fitting{}} | {error, Reason::term()}.
+         {ok, Pipe::#pipe{}} | {error, Reason::term()}.
 new_pipeline(Spec, Options) ->
     case supervisor:start_child(?MODULE, [Spec, Options]) of
         {ok, Pid, Ref} ->
-            riak_pipe_builder:get_first_fitting(Pid, Ref);
+            {ok, Fittings} = riak_pipe_builder:get_fittings(Pid, Ref),
+            {sink, Sink} = lists:keyfind(sink, 1, Options),
+            {ok, #pipe{builder=Pid, fittings=Fittings, sink=Sink}};
         Error ->
             Error
     end.

--- a/src/riak_pipe_log.erl
+++ b/src/riak_pipe_log.erl
@@ -41,7 +41,7 @@ log(#fitting_details{options=O, name=N}, Msg) ->
             ok; %% no logging
         sink ->
             Sink = proplists:get_value(sink, O),
-            riak_pipe:log(N, Sink, Msg);
+            riak_pipe_sink:log(N, Sink, Msg);
         sasl ->
             error_logger:info_msg(
               "Pipe log -- ~s:~n~P",

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -1,0 +1,54 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Methods for sending messages to the sink.
+%%
+%%      Sink messages are delivered as three record types:
+%%      `#pipe_result{}', `#pipe_log{}', and `#pipe_eoi{}'.
+-module(riak_pipe_sink).
+
+-export([
+         result/3,
+         log/3,
+         eoi/1
+        ]).
+
+-include("riak_pipe.hrl").
+
+%% @doc Send a result to the sink (used by worker processes).  The
+%%      result is delivered as a `#pipe_result{}' record in the sink
+%%      process's mailbox.
+-spec result(term(), Sink::riak_pipe:fitting(), term()) -> #pipe_result{}.
+result(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Output) ->
+    Pid ! #pipe_result{ref=Ref, from=From, result=Output}.
+
+%% @doc Send a log message to the sink (used by worker processes and
+%%      fittings).  The message is delivered as a `#pipe_log{}' record
+%%      in the sink process's mailbox.
+-spec log(term(), Sink::riak_pipe:fitting(), term()) -> #pipe_log{}.
+log(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Msg) ->
+    Pid ! #pipe_log{ref=Ref, from=From, msg=Msg}.
+
+%% @doc Send an end-of-inputs message to the sink (used by fittings).
+%%      The message is delivered as a `#pipe_eoi{}' record in the sink
+%%      process's mailbox.
+-spec eoi(Sink::riak_pipe:fitting()) -> #pipe_eoi{}.
+eoi(#fitting{pid=Pid, ref=Ref, chashfun=sink}) ->
+    Pid ! #pipe_eoi{ref=Ref}.

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -273,7 +273,7 @@ send_output(Output, FromPartition,
             Timeout, UsedPreflist) ->
     case FittingOverride#fitting.chashfun of
         sink ->
-            riak_pipe:result(Name, FittingOverride, Output),
+            riak_pipe_sink:result(Name, FittingOverride, Output),
             ok;
         follow ->
             %% TODO: should 'follow' use the original preflist (in

--- a/src/riak_pipe_w_rec_countdown.erl
+++ b/src/riak_pipe_w_rec_countdown.erl
@@ -28,10 +28,10 @@
 %%```
 %% Spec = [#fitting_spec{name=counter,
 %%                       module=riak_pipe_w_rec_countdown}],
-%% {ok, Head, Sink} = riak_pipe:exec(Spec, []),
-%% riak_pipe_vnode:queue_work(Head, 3),
-%% riak_pipe_fitting:eoi(Head),
-%% {eoi, Results, []} = riak_pipe:collect_results(Sink).
+%% {ok, Pipe} = riak_pipe:exec(Spec, []),
+%% riak_pipe:queue_work(Pipe, 3),
+%% riak_pipe:eoi(Pipe),
+%% {eoi, Results, []} = riak_pipe:collect_results(Pipe).
 %% [{counter,0},{counter,1},{counter,2},{counter,3}] = Results.
 %%'''
 %%
@@ -51,10 +51,10 @@
 %%                       module=riak_pipe_w_rec_countdown,
 %%                       arg=testeoi}],
 %% Options = [{trace,[restart]},{log,sink}],
-%% {ok, Head, Sink} = riak_pipe:exec(Spec, Options),
-%% riak_pipe_vnode:queue_work(Head, 3),
-%% riak_pipe_fitting:eoi(Head),
-%% {eoi, Results, Trace} = riak_pipe:collect_results(Sink).
+%% {ok, Pipe} = riak_pipe:exec(Spec, Options),
+%% riak_pipe:queue_work(Pipe, 3),
+%% riak_pipe:eoi(Pipe),
+%% {eoi, Results, Trace} = riak_pipe:collect_results(Pipe).
 %% [{counter,0},{counter,0},{counter,0},
 %%  {counter,1},{counter,2},{counter,3}] = Results.
 %% [{counter,{trace,[restart],{vnode,{restart,_}}}}] = Trace.


### PR DESCRIPTION
- riak_pipe:exec now returns {ok, Pipe}, not {ok, Head, Sink}
  - clients should call riak_pipe:queue_work(Pipe, Input) instead of
    riak_pipe_vnode:queue_work(Head, Input)
  - clients should call riak_pipe:eoi(Pipe) instead of
    riak_pipe_fitting:eoi(Head)
  - all functions in the riak_pipe module that expected Head or Sink
    now expect Pipe
