### PR TITLE
AZ 479: If no workers were created for this fitting, optionally fake star

### DIFF
--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -185,13 +185,13 @@ wait_upstream_eoi({eoi, Ref},
         %% to fake spinning up a single worker and have it send its
         %% result downstream (which is done as a side-effect of
         %% calling wait_for_input()).
-        true = (Details#fitting_details.module):no_input_run_reduce_once(),
-        FakePartition = 0,
-        {ok, _WStateName1, WState1, 0} =
-            riak_pipe_vnode_worker:init([FakePartition, fake_pid, Details]),
-        {stop, normal, _WState2} =
-            riak_pipe_vnode_worker:wait_for_input({input, done}, WState1)
-    catch error:undef ->
+        #fitting_details{module=Module, options=Os0} = Details,
+        true = Module:no_input_run_reduce_once(),
+        Os = [pipe_fitting_no_input|Os0],
+        {ok, WState1} = Module:init(0, Details#fitting_details{options=Os}),
+        _ = Module:done(WState1)
+    catch
+        error:_ ->                              % undef or badmatch
             ok
     end,
     forward_eoi(State),

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -70,7 +70,7 @@
 %%      needs to clean up, and send any outputs it still needs to
 %%      send.  When `done/1' returns, the worker will terminate.
 %%
-%%      There are also three optional functions that a worker behavior
+%%      There are also four optional functions that a worker behavior
 %%      module can export:
 %%
 %% ```
@@ -106,6 +106,25 @@
 %%      the `Archive' with its `ModuleState' (in whatever sense
 %%      "merge" may mean for this fitting), and return the resulting
 %%      `NewModuleState'.
+%%
+%% ```
+%% no_input_run_reduce_once() -> boolean().
+%% '''
+%%
+%% If present and returns `true', then in the case that a fitting has
+%% no input (as measured by having zero workers), then a "fake" worker
+%% will be started for the express purpose of running its computation
+%% once and sending some output downstream.  Right now, the only
+%% fitting that needs this feature is riak_kv_w_reduce.erl, which
+%% needs the capability to run its reduce function once (with input of
+%% an empty list) in order to maintain full compatibility with Riak
+%% KV's Map/Reduce.
+%%
+%% For riak_kv_w_reduce.erl and any other pipe behavior callback
+%% module where this function returns `true', the
+%% `#fitting_details.options' property list will contain the property
+%% `pipe_fitting_no_input' to indicate that the fitting has no input.
+%%
 -module(riak_pipe_vnode_worker).
 
 -behaviour(gen_fsm).


### PR DESCRIPTION
AZ 479: If no workers were created for this fitting, optionally fake starting one worker.

To assist some fittings, such as riak_kv_w_reduce, we need to fake
spinning up a single worker and have it send its result downstream
(which is done as a side-effect of calling wait_for_input()).

The use of the special pipe behavior callback func,
no_input_run_reduce_once(), is a kludge, but it's the least-ugly
solution that I can think of.  During pipe construction, the riak_kv
map-reduce cannot calculate The 100% Correct All The Time(tm) term
to send to a reduce phase when there is no input to that reduce phase;
therefore adding a magic fitting somewhere in the mapred compatibility layer
isn't an option.  And when there is no input to a reduce phase, control is
never passed to riak_kv_w_reduce because, by definition, no worker has ever
been created; therefore riak_kv_w_reduce cannot influence
riak_pipe_fitting's actions.
