### PR TITLE
A first shot at basic Pipe status

### DIFF
--- a/README.org
+++ b/README.org
@@ -341,6 +341,56 @@ See the [[Receiving outputs]] section above for details about using the
 =riak_pipe= instead of pulling these records out of a mailbox
 explicitly.
 
+*** Inspecting Performance
+
+While a pipeline is running, some information about what its workers
+are up to can be fetched using =riak_pipe:status/1=.  For example:
+
+#+BEGIN_SRC
+{ok, Pipe} = riak_pipe:example_start().
+ok = riak_pipe:queue_work(Pipe, "foo").
+Status = riak_pipe:status(Pipe).
+#+END_SRC
+
+The code above starts a pipeline with one fitting named =empty_pass=,
+sends it one input, and then requests its status.  The =Status=
+received on the last line, will be something like the following:
+
+#+BEGIN_SRC
+[{empty_pass,[[{node,'riak@127.0.0.1'},
+               {partition,22835963083295358096932575511191922182123945984},
+               {fitting,<0.469.0>},
+               {name,empty_pass},
+               {module,riak_pipe_w_pass},
+               {state,waiting},
+               {inputs_done,false},
+               {queue_length,0},
+               {blocking_length,0},
+               {started,{1308,854463,966730}},
+               {processed,1},
+               {failures,0},
+               {work_time,52},
+               {idle_time,10054032}]]}]
+#+END_SRC
+
+That is, =Status= is a list with one entry per fitting.  The example
+pipeline had only one fitting, so this list has only one entry.
+
+Each fitting's entry is a 2-tuple of the form ={Name, WorkerList}=.
+The =Name= is the name provided to =riak_pipe:exec/2=, or =empty_pass=
+in our example case.  =WorkerList= is a list containing the status of
+each worker.
+
+The status of each worker is represented as a proplist of details.
+Since the example sent only one input, and it was processed
+successfully, only one worker exists in this example list.  The details
+indicate which node the worker is running on, and which partition
+(vnode) it's working for.  The also indicate that there's nothing more
+waiting in the worker's queue, that one inputs was processed, and that
+it took 52 microseconds to process that input.  Details about the
+other fields in this proplist can be found in the documentation of
+=riak_pipe_vnode:status/1=.
+
 ** Behavior
 
 Fitting behaviors have it easy.  They need only expose three

--- a/include/riak_pipe.hrl
+++ b/include/riak_pipe.hrl
@@ -28,7 +28,7 @@
 -record(pipe,
         {
           builder :: pid(),
-          fittings :: [#fitting{}],
+          fittings :: [{Name::term(), #fitting{}}],
           sink :: #fitting{}
         }).
 

--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -371,7 +371,17 @@ active_pipelines(Node) when is_atom(Node) ->
             Pipes
     end.
 
-%% @doc 
+%% @doc Retrieve details about the status of the workers in this
+%%      pipeline.  The form of the return is a list with one entry per
+%%      fitting in the pipe.  Each fitting's entry is a 2-tuple of the
+%%      form `{FittingName, WorkerDetails}', where `FittingName' is
+%%      the name that was given to the fitting in the call to {@link
+%%      riak_pipe:exec/2}, and `WorkerDetails' is a list with one
+%%      entry per worker.  Each worker entry is a proplist, of the
+%%      form returned by {@link riak_pipe_vnode:status/1}, with two
+%%      properties added: `node', the node on which the worker is
+%%      running, and `partition', the index of the vnode that the
+%%      worker belongs to.
 -spec status(pipe())
          -> [{FittingName::term(),[PartitionStatus::[stat()]]}].
 status(#pipe{fittings=Fittings}) ->

--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -541,7 +541,7 @@ extract_unblocking(Trace) ->
 
 extract_restart_fail(Trace) ->
     [Partition ||
-        {_, {trace, _, {vnode, {restart_fail, Partition}}}} <- Trace].
+        {_, {trace, _, {vnode, {restart_fail, Partition, _}}}} <- Trace].
 
 kill_all_pipe_vnodes() ->
     [exit(VNode, kill) ||

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -95,8 +95,11 @@ pipeline(BuilderPid) ->
 init([Spec, Options]) ->
     {sink, #fitting{ref=Ref}=Sink} = lists:keyfind(sink, 1, Options),
     Fittings = start_fittings(Spec, Options),
+    NamedFittings = lists:zip(
+                      [ N || #fitting_spec{name=N} <- Spec ],
+                      [ F || {F, _R} <- Fittings ]),
     Pipe = #pipe{builder=self(),
-                 fittings=[ F || {F, _R} <- Fittings ],
+                 fittings=NamedFittings,
                  sink=Sink},
     put(eunit, [{module, ?MODULE},
                 {ref, Ref},

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -30,7 +30,7 @@
 %% API
 -export([start_link/2]).
 -export([fitting_pids/1,
-         get_fittings/2]).
+         pipeline/1]).
 
 %% gen_fsm callbacks
 -export([init/1,
@@ -46,7 +46,7 @@
 -include("riak_pipe_debug.hrl").
 
 -record(state, {options :: riak_pipe:exec_opts(),
-                ref :: reference(),
+                pipe :: #pipe{},
                 alive :: [{#fitting{}, reference()}]}). % monitor ref
 
 -opaque state() :: #state{}.
@@ -78,12 +78,12 @@ fitting_pids(Builder) ->
             gone
     end.
 
-%% @doc Get the `#fitting{}' records describing the fittings in
-%%      this builder's pipeline.  This function will block until the
-%%      builder has finished building the pipeline.
--spec get_fittings(pid(), reference()) -> {ok, [riak_pipe:fitting()]}.
-get_fittings(BuilderPid, Ref) ->
-    gen_fsm:sync_send_event(BuilderPid, {get_fittings, Ref}).
+%% @doc Get the `#pipe{}' record describing the pipeline created by
+%%      this builder.  This function will block until the builder has
+%%      finished building the pipeline.
+-spec pipeline(pid()) -> {ok, #pipe{}} | gone.
+pipeline(BuilderPid) ->
+    gen_fsm:sync_send_event(BuilderPid, pipeline).
 
 %%%===================================================================
 %%% gen_fsm callbacks
@@ -93,8 +93,11 @@ get_fittings(BuilderPid, Ref) ->
 -spec init([ [riak_pipe:fitting_spec()] | riak_pipe:exec_opts() ]) ->
          {ok, wait_pipeline_shutdown, state()}.
 init([Spec, Options]) ->
-    {sink, #fitting{ref=Ref}} = lists:keyfind(sink, 1, Options),
+    {sink, #fitting{ref=Ref}=Sink} = lists:keyfind(sink, 1, Options),
     Fittings = start_fittings(Spec, Options),
+    Pipe = #pipe{builder=self(),
+                 fittings=[ F || {F, _R} <- Fittings ],
+                 sink=Sink},
     put(eunit, [{module, ?MODULE},
                 {ref, Ref},
                 {spec, Spec},
@@ -102,7 +105,7 @@ init([Spec, Options]) ->
                 {fittings, Fittings}]),
     {ok, wait_pipeline_shutdown,
      #state{options=Options,
-            ref=Ref,
+            pipe=Pipe,
             alive=Fittings}}.
 
 %% @doc All fittings have been started, and the builder is just
@@ -114,18 +117,14 @@ wait_pipeline_shutdown(_Event, State) ->
     {next_state, wait_pipeline_shutdown, State}.
 
 %% @doc A client is asking for the fittings.  Respond.
--spec wait_pipeline_shutdown({get_fittings, reference()},
-                             term(), state()) ->
+-spec wait_pipeline_shutdown(pipeline, term(), state()) ->
          {reply,
-          {ok, [riak_pipe:fitting()]},
+          {ok, #pipe{}},
           wait_pipeline_shutdown,
           state()}.
-wait_pipeline_shutdown({get_fittings, Ref}, _From,
-                       #state{ref=Ref,
-                              alive=FittingRefs}=State) ->
+wait_pipeline_shutdown(pipeline, _From, #state{pipe=Pipe}=State) ->
     %% everything is started - reply now
-    Fittings = [ F || {F, _Ref} <- FittingRefs ],
-    {reply, {ok, Fittings}, wait_pipeline_shutdown, State};
+    {reply, {ok, Pipe}, wait_pipeline_shutdown, State};
 wait_pipeline_shutdown(_, _, State) ->
     %% unknown message - reply {error, unknown} to get rid of it
     {reply, {error, unknown}, wait_pipeline_shutdown, State}.

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -385,6 +385,28 @@ reply_archive(Pid, Fitting, Archive) ->
 %%      `blocking_length'
 %%</dt><dd>
 %%      Integer number of requests blocking on the queue.
+%%</dd><dt>
+%%      `started'
+%%</dt><dd>
+%%      An {@link erlang:now/0} tuple, indicating the time that the
+%%      worker started.
+%%</dd><dt>
+%%      `processed'
+%%</dt><dd>
+%%      Integer number of inputs that the worker has processed.
+%%</dd><dt>
+%%      `work_time'
+%%</dt><dd>
+%%      Total time the worker has spent processing inputs (as opposed
+%%      to waiting, idle for them).  Given as an integer number of
+%%      microseconds.
+%%</dd><dt>
+%%      `idle_time'
+%%</dt><dd>
+%%      Total time the worker has spent waiting for inputs (as opposed
+%%      to working on them).  Given as an integer number of
+%%      microseconds.  Should be roughly equal to
+%%      `(now()-started)-work_time'.
 %%</dd></dl>
 -spec status(pid()) -> {partition(), [[{atom(), term()}]]}.
 status(Pid) ->

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -67,20 +67,17 @@
                 | timeout
                 | forwarding
                 | preflist_exhausted.
--type now() :: {non_neg_integer(),
-                non_neg_integer(),
-                non_neg_integer()}.
 
 -define(DEFAULT_WORKER_LIMIT, 50).
 -define(DEFAULT_WORKER_Q_LIMIT, 64).
 -define(FORWARD_WORKER_MODULE, riak_pipe_w_fwd).
 
--record(worker_perf, {started :: now(),
+-record(worker_perf, {started :: calendar:t_now(),
                        processed = 0 :: non_neg_integer(),
                        failures = 0 :: non_neg_integer(),
                        work_time = 0 :: non_neg_integer(),
                        idle_time = 0 :: non_neg_integer(),
-                       last_time :: now()}).
+                       last_time :: calendar:t_now()}).
 -record(worker, {pid :: pid(),
                  fitting :: #fitting{},
                  details :: #fitting_details{},

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -395,6 +395,11 @@ reply_archive(Pid, Fitting, Archive) ->
 %%</dt><dd>
 %%      Integer number of inputs that the worker has processed.
 %%</dd><dt>
+%%      `failures'
+%%</dt><dd>
+%%      Integer number of times that the worker has failed (and was
+%%      restarted).
+%%</dd><dt>
 %%      `work_time'
 %%</dt><dd>
 %%      Total time the worker has spent processing inputs (as opposed
@@ -1115,6 +1120,7 @@ proplist_perf(#worker{perf=Perf, state=State}) ->
                          end,
     [{started, Perf#worker_perf.started},
      {processed, Perf#worker_perf.processed},
+     {failures, Perf#worker_perf.failures},
      {work_time, Perf#worker_perf.work_time + AddWork},
      {idle_time, Perf#worker_perf.idle_time + AddIdle}].
 


### PR DESCRIPTION
This PR contains a first shot at exposing runtime inspection of the status of live pipelines.  Through use of `riak_pipe:status/1`, the "status" of a live Pipe can be retrieved.  Much of the information in this status was already available through cluster_info, but this function provides it as pipeline-specific information, instead of node- or cluster-wide data.

A few new status types have been added as well: started, processed, failures, work_time, and idle_time.  They document the time the worker started, how many inputs it has processed, how many times it has failed, how much wall-clock time it has spent actively processing inputs, and how much wall-clock time it has spent waiting for inputs, respectively.

Potentials for future work in this department:
    - aggregating this information over time
    - other stats like the time it takes an input to move through a queue, and time inputs spend blocking
    - moving the work/idle time closer to the worker, and thereby also clocking the time spent in messaging overhead through the vnode

I feel this branch has had enough stewing time to be considered as a first pass at some status exposure, though, so please review.
