### PR TITLE
AZ374 per-fitting queue limits

### DIFF
--- a/README.org
+++ b/README.org
@@ -178,9 +178,15 @@ in =include/riak_pipe.hrl=.
                               %% specification of how to distribute
                               %% inputs for this fitting
 
-   nval = 1 %% positive integer, default 1, indicates how many vnodes
+   nval = 1,%% positive integer, default 1, indicates how many vnodes
             %% may be asked to handle an input for this fitting,
             %% before declaring the input unfit for processing
+
+   q_limit = 64 %% positive integer, default 64, sets the maximum
+                %% number of elements allowed in a worker's queue,
+                %% the actual queue limit is the lesser of this value
+                %% and the worker_q_limit variable in riak_pipe's
+                %% application environment (default 4096)
 }
 #+END_SRC
 

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -71,5 +71,5 @@ riak_core_pb.erl:132: The pattern <Binary, 'string'> can never match the type <'
 ###
 ### Warnings from validation code, where user code might violate -spec
 ###
-riak_pipe_fitting.erl:496: The variable NVal can never match since previous clauses completely covered the type fun((_) -> pos_integer()) | pos_integer()
-
+riak_pipe_fitting.erl:522: The variable NVal can never match since previous clauses completely covered the type fun((_) -> pos_integer()) | pos_integer()
+riak_pipe_fitting.erl:536: The variable QLimit can never match since previous clauses completely covered the type pos_integer()

--- a/include/riak_pipe.hrl
+++ b/include/riak_pipe.hrl
@@ -13,7 +13,8 @@
           module :: atom(),
           arg :: term(),
           output :: #fitting{},
-          options :: riak_pipe:exec_opts()
+          options :: riak_pipe:exec_opts(),
+          q_limit :: pos_integer()
         }).
 
 -record(fitting_spec,
@@ -22,7 +23,8 @@
           module :: atom(),
           arg :: term(),
           chashfun = fun chash:key_of/1 :: riak_pipe_vnode:chashfun(),
-          nval = 1 :: riak_pipe_vnode:nval()
+          nval = 1 :: riak_pipe_vnode:nval(),
+          q_limit = 64 :: pos_integer()
         }).
 
 -record(pipe,

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -525,6 +525,8 @@ validate_nval(NVal) ->
               " or a function of arity 1; not a ~p",
               [riak_pipe_v:type_of(NVal)])}.
 
+%% @doc Validate the q_limit parameter.  This must be a positive integer.
+-spec validate_q_limit(term()) -> ok | {error, string()}.
 validate_q_limit(QLimit) when is_integer(QLimit) ->
     if QLimit > 0 -> ok;
        true ->

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -141,7 +141,7 @@ crash(Pid, Fun) ->
             | riak_pipe:exec_opts()]) ->
          {ok, wait_upstream_eoi, state()}.
 init([Builder,
-      #fitting_spec{name=Name, module=Module, arg=Arg}=Spec,
+      #fitting_spec{name=Name, module=Module, arg=Arg, q_limit=QLimit}=Spec,
       Output,
       Options]) ->
     Fitting = fitting_record(self(), Spec, Output),
@@ -150,7 +150,8 @@ init([Builder,
                                module=Module,
                                arg=Arg,
                                output=Output,
-                               options=Options},
+                               options=Options,
+                               q_limit=QLimit},
     
     ?T(Details, [], {fitting, init_started}),
 
@@ -430,7 +431,8 @@ validate_fitting(#fitting_spec{name=Name,
                                module=Module,
                                arg=Arg,
                                chashfun=HashFun,
-                               nval=NVal}) ->
+                               nval=NVal,
+                               q_limit=QLimit}) ->
     case riak_pipe_v:validate_module("module", Module) of
         ok -> ok;
         {error, ModError} ->
@@ -462,6 +464,14 @@ validate_fitting(#fitting_spec{name=Name,
               "Invalid nval in fitting spec \"~s\":~n~s",
               [format_name(Name), NVError]),
             throw(badarg)
+    end,
+    case validate_q_limit(QLimit) of
+        ok -> ok;
+        {error, QLError} ->
+            error_logger:error_msg(
+              "Invalid q_limit in fitting spec \"~s\":~n~s",
+              [format_name(Name), QLError]),
+            throw(badard)
     end;
 validate_fitting(Other) ->
     error_logger:error_msg(
@@ -514,6 +524,17 @@ validate_nval(NVal) ->
               "expected a positive integer,"
               " or a function of arity 1; not a ~p",
               [riak_pipe_v:type_of(NVal)])}.
+
+validate_q_limit(QLimit) when is_integer(QLimit) ->
+    if QLimit > 0 -> ok;
+       true ->
+            {error, io_lib:format(
+                      "expected a positive integer, found ~p", [QLimit])}
+    end;
+validate_q_limit(QLimit) ->
+    {error, io_lib:format(
+              "expected a positive integer, not a ~p",
+              [riak_pipe_v:type_of(QLimit)])}.
 
 %% @doc Coerce a fitting name into a printable string.
 -spec format_name(term()) -> iolist().


### PR DESCRIPTION
`#fitting_spec.q_limit` can now be set to specify a different queue-length limit
for each fitting.  The application environment variable `worker_q_limit` is now
a global cap on that setting.  That is, the actual queue limit used is the
lesser of `#fitting_spec.q_limit` and the `riak_pipe:worker_q_limit` environment variable.
