### PR TITLE
fix {sink, #fitting{}} option validation

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -207,7 +207,7 @@ ensure_sink(Options) ->
                                   _ ->
                                       HFSink
                               end,
-                    lists:keyreplace(sink, 1, Options, RHFSink);
+                    lists:keyreplace(sink, 1, Options, {sink, RHFSink});
                true ->
                     throw({invalid_sink, nopid})
             end;


### PR DESCRIPTION
the post-validation code was replacing {sink, Fitting} with just Fitting.
lists:keyreplace expects the whole tuple
