### PR TITLE
Make sure epmd is running before eunit tests start net kernel.

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -789,7 +789,8 @@ prepare_runtime(_NodeName) ->
      fun() ->
              do_dep_apps(fullstop),
              timer:sleep(5),
-             %% Must start net_kernel before starting apps
+             %% Must start epmd/net_kernel before starting apps
+             [] = os:cmd("epmd -daemon"),
              net_kernel:start([_NodeName, shortnames]), 
              do_dep_apps(start),
              timer:sleep(5),


### PR DESCRIPTION
Fixes the error below if the host the test runs on does not have epmd started.

<pre>
=INFO REPORT==== 4-Aug-2011::08:01:18 ===
Protocol: "inet_tcp": register error: {{badmatch,{error,econnrefused}},
                                       [{inet_tcp_dist,listen,1},
                                        {net_kernel,start_protos,4},
                                        {net_kernel,start_protos,3},
                                        {net_kernel,init_node,2},
                                        {net_kernel,init,1},
                                        {gen_server,init_it,6},
                                        {proc_lib,init_p_do_apply,3}]}
</pre>
