### PR TITLE
quietly ignore worker requests for input from queues that don't exist

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -861,7 +861,15 @@ next_input_internal(#cmd_next_input{fitting=Fitting}, State) ->
             send_handoff(Worker),
             HandoffWorker = Worker#worker{state={working, handoff},
                                           handoff=undefined},
-            {noreply, replace_worker(HandoffWorker, State)}
+            {noreply, replace_worker(HandoffWorker, State)};
+        none ->
+            %% this next_input request was for a queue that this vnode
+            %% doesn't have.  ignore it.  (one example is if the vnode
+            %% receives a 'DOWN' for a fitting, and cleans up the
+            %% queue for that fitting's worker *after* the worker has
+            %% requested its next input, but before the vnode has
+            %% received that request)
+            {noreply, State}
     end.
 
 %% @doc Handle pulling data off of a worker's queue and sending it to


### PR DESCRIPTION
Fix for https://issues.basho.com/show_bug.cgi?id=1153

The likely cause of BZ1153 is that the vnode received a `'DOWN'` for the fitting process, and deleted the queue for that fitting _after_ the worker for that fitting had already sent its next_input request.  This led the vnode to pick up a next_input request that pointed to a queue it no longer had.

An alternate fix might be to hang onto the queue, but mark it as dead, until the exit for the worker is received.
