### PR TITLE
return a valid value from handle_handoff_command(#cmd_eoi...

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -477,7 +477,8 @@ handle_handoff_command(#cmd_eoi{fitting=F}=Cmd, Sender, State) ->
         none ->
             %% handed off, or never existed: reply done
             %% (let the other node deal with its own eoi)
-            send_done(F)
+            send_done(F),
+            {noreply, State}
     end;
 handle_handoff_command(#cmd_next_input{fitting=F}, _Sender, State) ->
     %% force workers into waiting state so we can ask them to


### PR DESCRIPTION
In the case where an eoi arrived for a non-existent fitting worker, the
result of 'send_done', usually 'ok', was returned.  That result would
have caused a badmatch in riak_core_vnode:vnode_handoff_command, so
return {noreply, State} after sending the done message instead.

This might be the cause of the reports of spurious handoff error messages/failures.
