### PR TITLE
Two simple dialyzer fixes

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -471,7 +471,7 @@ fitting_workers(#fitting{pid=Pid}=Fitting) ->
 %%      fittings on that partition.  The closure over the Ring is a
 %%      way to map over a list without having to fetch the ring
 %%      repeatedly.
--spec worker_status(riak_core_ring:ring())
+-spec worker_status(riak_core_ring:riak_core_ring())
          -> fun( (riak_pipe_vnode:partition(), [#fitting{}])
                  -> [ [{atom(), term()}] ] ).
 worker_status(Ring) ->

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -58,7 +58,8 @@
               chash/0,
               partition/0, %% from riak_core_vnode.hrl
               nval/0,
-              qtimeout/0]).
+              qtimeout/0,
+              qerror/0]).
 -type chashfun() :: fun((term()) -> chash()) | follow | sink.
 -type chash() :: chash:index().
 -type nval() :: pos_integer() | fun((term()) -> pos_integer()).


### PR DESCRIPTION
Exporting `riak_pipe_vnode:qerror/0` for `riak_pipe` to use, and using the correct name (`riak_core_ring/0`, not just `ring/0`) for `riak_core_ring`'s type.
