### PR TITLE
Monitor the sink from the builder process; tear down the pipe if the sink dies.

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -60,6 +60,7 @@
          queue_work/2,
          queue_work/3,
          eoi/1,
+         destroy/1,
          status/1,
          active_pipelines/1
         ]).
@@ -362,6 +363,14 @@ collect_results(Pipe, ResultAcc, LogAcc, Timeout) ->
             %% but it's useful to have logging output in time order
             {End, ResultAcc, lists:reverse(LogAcc)}
     end.
+
+%% @doc Brutally kill a pipeline.  Use this when it is necessary to
+%%      stop all parts of a pipeline as quickly as possible, instead
+%%      of waiting for an `eoi' to propagate through.
+-spec destroy(pipe()) -> ok.
+destroy(#pipe{builder=Builder}) ->
+    erlang:exit(Builder, kill),
+    ok.
 
 %% @doc Get all active pipelines hosted on `Node'.  Pass the atom
 %%      `global' instead of a node name to get all pipelines hosted on

--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -1509,8 +1509,10 @@ exception_test_() ->
                                          N <- lists:seq(50, 60)],
                                      timer:sleep(500),
                                      exit((Pipe2#pipe.sink)#fitting.pid,
-                                          please_die_now),
-                                     exit(normal)
+                                          please_die_now)
+                                     %% Due to the way Spec is written,
+                                     %% this proc _is_ the sink, so we've
+                                     %% just killed ourself.
                              end),
                        timer:sleep(3000),
                        AfterProcs = processes(),


### PR DESCRIPTION
Since the sink is where output is sent, it is assumed that when the sink dies, the rest of the output is no longer interesting, so we may as well tear down the pipe and reclaim its resources.  This patch handles that by monitoring the sink process from the builder process.  If the sink dies, the builder stops itself.  Fittings are linked to the builder, so they tear down.  Vnodes monitor the fittings they're running workers for, so they notice the exits and tear down the workers.  Resources reclaimed.

As noted in the commit, there's a small chance that a sink that shuts down immediately after receiving `eoi` could get its `DOWN` to the builder before the final fitting's `EXIT` arrives.  If this happens, the death of the builder will be noted in the log (because it will exit abnormally), but there will be no data lost (because it all made it to the sink before `eoi`).
