### PR TITLE
AZ668 Provide 'covering' enqueue operation

### DIFF
--- a/src/riak_pipe_qcover_fsm.erl
+++ b/src/riak_pipe_qcover_fsm.erl
@@ -1,0 +1,76 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_pipe_qcover_fsm: enqueueing on a covering set of vnodes
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc The qcover fsm manages enqueueing the same work on a set of
+%%      vnodes that covers the space of data with a replication factor
+%%      of N.  This can be used, for example, to ask 1/Xth of the
+%%      cluster to list keys for data stored in Riak KV with N=X.
+%%
+%%      When using qcover to send `Input', workers for the fitting
+%%      will receive input of the form `{cover, FilterVNodes, Input}'.
+%%
+%%      IMPORTANT: Fittings that will receive their inputs via this
+%%      qcover fsm should be started with their nval=1.  Pipe nval
+%%      failover should not be used with qcover inputs, because the
+%%      vnode filter is meant only for the vnode that initially
+%%      receives the request.
+%%
+%%      Note also that the chashfun fitting parameter has no effect
+%%      when using qcover.  Coverage is computed purely via the
+%%      qcover's NVal.
+
+-module(riak_pipe_qcover_fsm).
+
+-behaviour(riak_core_coverage_fsm).
+
+-export([init/2,
+         process_results/2,
+         finish/2]).
+
+-include("riak_pipe.hrl").
+
+-record(state, {from}).
+
+init(From, [#pipe{fittings=[{_Name, Fitting}|_]}, Input, NVal]) ->
+    Req = {Fitting, Input},
+    {Req,                    %% Request
+     all,                    %% VNodeSelector
+     NVal,                   %% NVal
+     1,                      %% PrimaryVNodeCoverage
+     riak_pipe,              %% NodeCheckService
+     riak_pipe_vnode_master, %% VNodeMaster
+     infinity,               %% Timeout
+     #state{from=From}}.     %% State
+
+process_results(ok, State) ->
+    %% this 'done' means that the vnode that sent this reply is done,
+    %% not that the entire request is done
+    {done, State};
+process_results(Error, State) ->
+    {Error, State}.
+
+finish({error, Reason}, #state{from={raw, Ref, Client}}=State) ->
+    Client ! {Ref, {error, Reason}},
+    {stop, normal, State};
+finish(clean, #state{from={raw, Ref, Client}}=State) ->
+    Client ! {Ref, done},
+    {stop, normal, State}.

--- a/src/riak_pipe_qcover_sup.erl
+++ b/src/riak_pipe_qcover_sup.erl
@@ -1,0 +1,48 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_pipe_qcover_sup: supervise the riak_pipe qcover state machines.
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc supervise the riak_pipe qcover state machines
+
+-module(riak_pipe_qcover_sup).
+
+-behaviour(supervisor).
+
+-export([start_qcover_fsm/1]).
+-export([start_link/0]).
+-export([init/1]).
+
+start_qcover_fsm(Args) ->
+    supervisor:start_child(?MODULE, Args).
+
+%% @spec start_link() -> ServerRet
+%% @doc API for starting the supervisor.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @spec init([]) -> SupervisorTree
+%% @doc supervisor callback.
+init([]) ->
+    FsmSpec = {undefined,
+               {riak_core_coverage_fsm, start_link, [riak_pipe_qcover_fsm]},
+               temporary, 5000, worker, [riak_pipe_qcover_fsm]},
+
+    {ok, {{simple_one_for_one, 10, 10}, [FsmSpec]}}.

--- a/src/riak_pipe_sup.erl
+++ b/src/riak_pipe_sup.erl
@@ -71,4 +71,7 @@ init([]) ->
     FSup = {riak_pipe_fitting_sup,
             {riak_pipe_fitting_sup, start_link, []},
             permanent, 5000, supervisor, [riak_pipe_fitting_sup]},
-    {ok, { {one_for_one, 5, 10}, [VMaster, BSup, FSup]} }.
+    CSup = {riak_pipe_qcover_sup,
+            {riak_pipe_qcover_sup, start_link, []},
+            permanent, 5000, supervisor, [riak_pipe_qcover_sup]},
+    {ok, { {one_for_one, 5, 10}, [VMaster, BSup, FSup, CSup]} }.

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -624,9 +624,18 @@ handle_info(_,State) ->
     %% unknown message
     {ok, State}.
 
-%% @doc Coverage is not used in riak_pipe yet.
+%% @doc Coverage requests may be used to enqueue identical work on
+%%      multiple vnodes.  `Input' is delivered to the worker as
+%%      `{cover, FilterVNodes, Input}'.
 -spec handle_coverage(term(), term(), sender(), state()) ->
          {reply, ok, state()}.
+handle_coverage({Fitting, Input}, FilterVNodes, Sender,
+                #state{partition=Partition}=State) ->
+    CoverInput = {cover, FilterVNodes, Input},
+    Cmd = #cmd_enqueue{fitting=Fitting, input=CoverInput,
+                       timeout=infinity,
+                       usedpreflist=[{Partition, node()}]},
+    handle_command(Cmd, Sender, State);
 handle_coverage(_Request, _KeySpaces, _Sender, State) ->
     {reply, ok, State}.
 


### PR DESCRIPTION
This PR is support for a Riak KV PR (https://github.com/basho/riak_kv/pull/193) that improves the performance of pipe-powered MapReduce when given bucket±filter inputs.

This patch adds a 'covering enqueue' operation to the Riak Pipe vnode.  Using `riak_pipe_qcover_fsm`, an input can be enqueued for a fitting on several vnodes at once.  The "coverage" is computed using the `Nval` passed to the FSM, by `riak_core_coverage_fsm`.
