### PR TITLE
catch sync_send_event in worker_done in case fitting is gone

### DIFF
--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -108,7 +108,7 @@ get_details(#fitting{pid=Pid, ref=Ref}, Partition) ->
 %%      assumes that it is being called from the vnode process, so
 %%      that `self()' can be used to inform the fitting of which
 %%      worker is done.
--spec worker_done(riak_pipe:fitting()) -> ok.
+-spec worker_done(riak_pipe:fitting()) -> ok | gone.
 worker_done(#fitting{pid=Pid, ref=Ref}) ->
     try
         gen_fsm:sync_send_event(Pid, {done, Ref, self()})

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -110,7 +110,11 @@ get_details(#fitting{pid=Pid, ref=Ref}, Partition) ->
 %%      worker is done.
 -spec worker_done(riak_pipe:fitting()) -> ok.
 worker_done(#fitting{pid=Pid, ref=Ref}) ->
-    gen_fsm:sync_send_event(Pid, {done, Ref, self()}).
+    try
+        gen_fsm:sync_send_event(Pid, {done, Ref, self()})
+    catch exit:_ ->
+            gone
+    end.
 
 %% @doc Get the list of ring partition indexes (vnodes) that are doing
 %%      work for this fitting.


### PR DESCRIPTION
https://issues.basho.com/1236

In timeout and other error cases that tear down the whole pipeline, it's
possible that a worker may finish its work and cause the vnode to report
back to the fitting process after that process has already exited.  This
patch catches the exit that gen_fsm:sync_send_event would otherwise force in
this case, to prevent the vnode (which is calling this method) from falling
over.
