### PR TITLE
Allow {mod, fun} tuples instead of anonymous funs for chash and nval (AZ561)

### DIFF
--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -64,8 +64,11 @@ validate_module(Label, Module) ->
 %%      If validation completes successfully, the atom `ok' is
 %%      returned.  If validation failes, an `{error, Reason}' tuple is
 %%      returned.  (`Label' is used in the error message).
--spec validate_function(string(), integer(), fun()) ->
+-spec validate_function(string(), integer(), fun() | {atom(), atom()}) ->
          ok | {error, iolist()}.
+validate_function(Label, Arity, {Module, Function})
+  when is_atom(Module), is_atom(Function) ->
+    validate_exported_function(Label, Arity, Module, Function);
 validate_function(Label, Arity, Fun) when is_function(Fun) ->
     Info = erlang:fun_info(Fun),
     case proplists:get_value(arity, Info) of
@@ -85,8 +88,9 @@ validate_function(Label, Arity, Fun) when is_function(Fun) ->
                                   [Label, Arity, N])}
     end;
 validate_function(Label, Arity, Fun) ->
-    {error, io_lib:format("~s must be a function (arity ~b), not a ~p",
-                          [Label, Arity, type_of(Fun)])}.
+    {error, io_lib:format(
+              "~s must be a function or {Mod, Fun} (arity ~b), not a ~p",
+              [Label, Arity, type_of(Fun)])}.
 
 %% @doc Validate an exported function.  See {@link validate_function/3}.
 -spec validate_exported_function(string(), integer(), atom(), atom()) ->

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -436,6 +436,8 @@ process_input(Input, UsedPreflist,
     Module = FD#fitting_details.module,
     NVal = case (FD#fitting_details.fitting)#fitting.nval of
                NValInt when is_integer(NValInt) -> NValInt;
+               {NValMod, NValFun}               -> NValMod:NValFun(Input);
+               %% 1.0.x compatibility
                NValFun                          -> NValFun(Input)
            end,
     try


### PR DESCRIPTION
Anonymous funs are too brittle: they break during rolling upgrades, when nodes do not share a common version of a module.  This patch allows using `{Module, Function}` tuples for chash and nval instead.

The tuples are allowed, but not used, here to give an intermediate step for upgrading from 1.0.1->1.0.2->1.1.0.  (This is the 1.0.2 step.)
