### PR TITLE
Use modfun tuples instead of anonymous funs (AZ561)

### DIFF
--- a/include/riak_pipe.hrl
+++ b/include/riak_pipe.hrl
@@ -22,7 +22,7 @@
           name :: term(),
           module :: atom(),
           arg :: term(),
-          chashfun = fun chash:key_of/1 :: riak_pipe_vnode:chashfun(),
+          chashfun = {chash, key_of} :: riak_pipe_vnode:chashfun(),
           nval = 1 :: riak_pipe_vnode:nval(),
           q_limit = 64 :: pos_integer()
         }).

--- a/src/riak_pipe_fun.erl
+++ b/src/riak_pipe_fun.erl
@@ -1,0 +1,48 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Utilities for dealing with anonymous funs.  This is most
+%% useful for upgrading from older pipes using funs to newer pipes
+%% using modfun tuples.
+
+-module(riak_pipe_fun).
+
+-export([compat_apply/2]).
+
+%% @doc Attempt to evaluate Fun(Inputs...). If the evaluation throws a
+%% badfun error, ask the module that defines the function for an
+%% alternate implementation, by calling `Module:compat_fun/1', and
+%% then evaluates that instead.
+compat_apply(Fun, Inputs) ->
+    try
+        apply(Fun, Inputs)
+    catch error:{badfun,Fun} ->
+            {module, Module} = erlang:fun_info(Fun, module),
+            try Module:compat_fun(Fun) of
+                {ok, CompatFun} ->
+                    apply(CompatFun, Inputs);
+                error ->
+                    %% just to re-raise the original badfun
+                    apply(Fun, Inputs)
+            catch error:undef ->
+                    %% just to re-raise the original badfun
+                    apply(Fun, Inputs)
+            end
+    end.

--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -64,8 +64,11 @@ validate_module(Label, Module) ->
 %%      If validation completes successfully, the atom `ok' is
 %%      returned.  If validation failes, an `{error, Reason}' tuple is
 %%      returned.  (`Label' is used in the error message).
--spec validate_function(string(), integer(), fun()) ->
+-spec validate_function(string(), integer(), fun() | {atom(), atom()}) ->
          ok | {error, iolist()}.
+validate_function(Label, Arity, {Module, Function})
+  when is_atom(Module), is_atom(Function) ->
+    validate_exported_function(Label, Arity, Module, Function);
 validate_function(Label, Arity, Fun) when is_function(Fun) ->
     Info = erlang:fun_info(Fun),
     case proplists:get_value(arity, Info) of
@@ -85,8 +88,9 @@ validate_function(Label, Arity, Fun) when is_function(Fun) ->
                                   [Label, Arity, N])}
     end;
 validate_function(Label, Arity, Fun) ->
-    {error, io_lib:format("~s must be a function (arity ~b), not a ~p",
-                          [Label, Arity, type_of(Fun)])}.
+    {error, io_lib:format(
+              "~s must be a function or {Mod, Fun} (arity ~b), not a ~p",
+              [Label, Arity, type_of(Fun)])}.
 
 %% @doc Validate an exported function.  See {@link validate_function/3}.
 -spec validate_exported_function(string(), integer(), atom(), atom()) ->

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -237,7 +237,8 @@ queue_work(#fitting{chashfun=Hash}=Fitting,
 queue_work(#fitting{chashfun=HashFun}=Fitting,
            Input, Timeout, UsedPreflist) ->
     %% 1.0.x compatibility
-    queue_work(Fitting, Input, Timeout, UsedPreflist, HashFun(Input)).
+    Hash = riak_pipe_fun:compat_apply(HashFun, [Input]),
+    queue_work(Fitting, Input, Timeout, UsedPreflist, Hash).
 
 %% @doc Queue the given `Input' for processing the the `Fitting' on
 %%      the vnode specified by `Hash'.  This version of the function
@@ -305,7 +306,8 @@ remaining_preflist(Input, Hash, NVal, UsedPreflist) ->
     IntNVal = if is_integer(NVal)  -> NVal;
                  is_tuple(NVal)    -> {Mod, Fun} = NVal, Mod:Fun(Input);
                  %% 1.0.x compatibility
-                 is_function(NVal) -> NVal(Input)
+                 is_function(NVal) ->
+                      riak_pipe_fun:compat_apply(NVal, [Input])
               end,
     %% it's possible that node availability changes could cause
     %% different vnodes to be available at different evaluations, so

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -436,6 +436,8 @@ process_input(Input, UsedPreflist,
     Module = FD#fitting_details.module,
     NVal = case (FD#fitting_details.fitting)#fitting.nval of
                NValInt when is_integer(NValInt) -> NValInt;
+               {NValMod, NValFun}               -> NValMod:NValFun(Input);
+               %% 1.0.x compatibility
                NValFun                          -> NValFun(Input)
            end,
     try

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -438,7 +438,8 @@ process_input(Input, UsedPreflist,
                NValInt when is_integer(NValInt) -> NValInt;
                {NValMod, NValFun}               -> NValMod:NValFun(Input);
                %% 1.0.x compatibility
-               NValFun                          -> NValFun(Input)
+               NValFun                          ->
+                   riak_pipe_fun:compat_apply(NValFun, [Input])
            end,
     try
         {Result, NewModState} = Module:process(Input,

--- a/src/riak_pipe_w_xform.erl
+++ b/src/riak_pipe_w_xform.erl
@@ -66,7 +66,8 @@ init(Partition, FittingDetails) ->
 -spec process(term(), boolean(), state()) -> {ok, state()}.
 process(Input, _Last, #state{p=Partition, fd=FittingDetails}=State) ->
     Fun = FittingDetails#fitting_details.arg,
-    ok = Fun(Input, Partition, FittingDetails),
+    ok = riak_pipe_fun:compat_apply(
+           Fun, [Input, Partition, FittingDetails]),
     {ok, State}.
 
 %% @doc Unused.


### PR DESCRIPTION
(rebased version of https://github.com/basho/riak_pipe/pull/32)

This is the second half of the migration to modfun tuples for chash and nval Pipe parameters. It includes the first half, which was made on the 1.0 branch for inclusion in 1.0.2.

The riak_pipe_fun:compat_apply/2 magic was necessary to ensure a stable rolling upgrade for Riak KV's MapReduce pipes. It should be general enough to be used by other functions, if necessary.
