### PR TITLE
reduce uninformative process death spam

### DIFF
--- a/README.org
+++ b/README.org
@@ -720,3 +720,10 @@ the same input as the =riak_client:mapred/2= function.  Support is
 currently provided for =map= and =reduce= phases implemented in
 Erlang, specified using the ={qfun, function()}= or ={modfun, Module,
 Function}= syntax.
+
+* Additional Documentation
+
+A diagram recording the supervisor/link/monitor structure of the
+Erlang processes involved in Riak Pipe is included in the file
+=riak_pipe_monitors.dot=.  The comments at the top of that file
+describe how to render it to an image using Graphviz.

--- a/riak_pipe_monitors.dot
+++ b/riak_pipe_monitors.dot
@@ -1,0 +1,98 @@
+// A map of the links and monitors among Riak Pipe processes
+
+// This map shows the basic web of monitors and links present in the
+// system when:
+//  - a pipeline "A" is setup with two fittings, "1" and "2"
+//  - a vnode is handling inputs for both of those fittings
+//     (only one vnode is shown, for simplicity in the diagram)
+
+// Edges are colored according to the type of link/monitor (or the
+// special-case link of supervision):
+//   supervises = [color="#009900"];
+//        links = [color="#990000"];
+//     monitors = [color="#000099"];
+
+// Render using Graphviz:
+//    dot -Tpng -oriak_pipe_monitors.png riak_pipe_monitors.dot
+
+// Notes:
+//  - the links from riak_pipe_vnode to riak_pipe_vnode_worker_A* were
+//     put in place before riak_core_vnode supported handle_info; they
+//     should be changed to monitors now
+digraph {
+   // application-immortal processes
+   subgraph apps {
+      rank=min;
+      riak_pipe_sup
+      riak_core_sup
+   }
+   
+   subgraph immortal {
+      {rank=same;
+         riak_pipe_vnode_master
+         riak_pipe_builder_sup
+         riak_pipe_fitting_sup
+         riak_core_vnode_sup}
+
+      // started at application start time
+      riak_pipe_sup -> riak_pipe_vnode_master [color="#009900"];
+      riak_pipe_sup -> riak_pipe_builder_sup [color="#009900"];
+      riak_pipe_sup -> riak_pipe_fitting_sup [color="#009900"];
+
+      // external to pipe
+      riak_core_sup -> riak_core_vnode_sup [color="#009900"];
+   }
+
+   // application-mortal processes
+   // started as vnode requests arrive
+   subgraph mortal {
+      riak_pipe_vnode
+      riak_pipe_vnode_worker_sup
+      
+      riak_core_vnode_sup -> riak_pipe_vnode [color="#009900"];
+      riak_pipe_vnode_master -> riak_pipe_vnode [color="#000099"];
+
+      riak_pipe_vnode -> riak_pipe_vnode_worker_sup [color="#990000"];
+   }
+   
+   // the builder/fitting "meta" processes
+   subgraph pipeline_meta_A {
+      riak_pipe_builder_A
+
+      riak_pipe_fitting_A1
+      riak_pipe_fitting_A2
+
+      // started as pipelines are set up
+      riak_pipe_builder_sup -> riak_pipe_builder_A [color="#009900"];
+
+      riak_pipe_fitting_sup -> riak_pipe_fitting_A1 [color="#009900"];
+      riak_pipe_fitting_sup -> riak_pipe_fitting_A2 [color="#009900"];
+
+      riak_pipe_builder_A -> riak_pipe_fitting_A1 [color="#000099"];
+      riak_pipe_builder_A -> riak_pipe_fitting_A2 [color="#000099"];
+
+      riak_pipe_fitting_A1 -> riak_pipe_builder_A [color="#000099"];
+      riak_pipe_fitting_A2 -> riak_pipe_builder_A [color="#000099"];
+
+      // builder also monitors the process receiving outputs
+      riak_pipe_builder_A -> sink_process_A [color="#000099"];
+   }
+
+   // the processes actually processing inputs
+   subgraph pipeline_A {
+      riak_pipe_vnode_worker_A1
+      riak_pipe_vnode_worker_A2
+
+      riak_pipe_vnode_worker_sup -> riak_pipe_vnode_worker_A1 [color="#009900"];
+      riak_pipe_vnode_worker_sup -> riak_pipe_vnode_worker_A2 [color="#009900"];
+
+      riak_pipe_vnode -> riak_pipe_vnode_worker_A1 [color="#990000"];
+      riak_pipe_vnode -> riak_pipe_vnode_worker_A2 [color="#990000"];
+
+      riak_pipe_vnode -> riak_pipe_fitting_A1 [color="#000099"];
+      riak_pipe_vnode -> riak_pipe_fitting_A2 [color="#000099"];
+
+      riak_pipe_fitting_A1 -> riak_pipe_vnode [color="#000099"];
+      riak_pipe_fitting_A2 -> riak_pipe_vnode [color="#000099"];
+   }
+}

--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -369,8 +369,7 @@ collect_results(Pipe, ResultAcc, LogAcc, Timeout) ->
 %%      of waiting for an `eoi' to propagate through.
 -spec destroy(pipe()) -> ok.
 destroy(#pipe{builder=Builder}) ->
-    erlang:exit(Builder, kill),
-    ok.
+    riak_pipe_builder:destroy(Builder).
 
 %% @doc Get all active pipelines hosted on `Node'.  Pass the atom
 %%      `global' instead of a node name to get all pipelines hosted on

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -90,7 +90,13 @@ pipeline(BuilderPid) ->
 %% @doc Shutdown the pipeline built by this builder.
 -spec destroy(pid()) -> ok.
 destroy(BuilderPid) ->
-    gen_fsm:sync_send_event(BuilderPid, destroy, infinity).
+    try
+        gen_fsm:sync_send_event(BuilderPid, destroy, infinity)
+    catch exit:_Reason ->
+            %% the builder exited before the call completed,
+            %% since we were shutting it down anyway, this is ok
+            ok
+    end.
 
 %%%===================================================================
 %%% gen_fsm callbacks

--- a/src/riak_pipe_fitting_sup.erl
+++ b/src/riak_pipe_fitting_sup.erl
@@ -25,7 +25,8 @@
 
 %% API
 -export([start_link/0]).
--export([add_fitting/4]).
+-export([add_fitting/4,
+         terminate_fitting/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -54,6 +55,13 @@ start_link() ->
 add_fitting(Builder, Spec, Output, Options) ->
     ?DPF("Adding fitting for ~p", [Spec]),
     supervisor:start_child(?SERVER, [Builder, Spec, Output, Options]).
+
+%% @doc Terminate a fitting immediately.  Useful for tearing down
+%% pipelines that may be otherwise swamped with messages from
+%% restarting workers.
+-spec terminate_fitting(riak_pipe:fitting()) -> ok | {error, term()}.
+terminate_fitting(#fitting{pid=Pid}) ->
+    supervisor:terminate_child(?SERVER, Pid).
 
 %%%===================================================================
 %%% Supervisor callbacks

--- a/src/riak_pipe_vnode_worker_sup.erl
+++ b/src/riak_pipe_vnode_worker_sup.erl
@@ -26,7 +26,8 @@
 
 %% API
 -export([start_link/2]).
--export([start_worker/2]).
+-export([start_worker/2,
+         terminate_worker/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -47,6 +48,11 @@ start_link(Partition, VnodePid) ->
 -spec start_worker(pid(), riak_pipe_fitting:details()) -> {ok, pid()}.
 start_worker(Supervisor, Details) ->
     supervisor:start_child(Supervisor, [Details]).
+
+%% @doc Stop a worker immediately
+-spec terminate_worker(pid(), pid()) -> ok | {error, term()}.
+terminate_worker(Supervisor, WorkerPid) ->
+    supervisor:terminate_child(Supervisor, WorkerPid).
 
 %%%===================================================================
 %%% Supervisor callbacks


### PR DESCRIPTION
Using supervisor:terminate_child/2 instead of erlang:exit/2 means that
the supervisor doesn't complain about the untimely death of its worker
process.  Combine this with changing the fittings from linking to
monitoring of the builder process (so the builder isn't torn down
abnormally when a fitting dies), and you get the end of "fitting_died"
spam.
