### PR TITLE
Make the tests wait for the riak_pipe service to be up. 

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -802,7 +802,7 @@ prepare_runtime(NodeName) ->
              [] = os:cmd("epmd -daemon"),
              net_kernel:start([NodeName, shortnames]), 
              do_dep_apps(start),
-             timer:sleep(5),
+             riak_core:wait_for_service(riak_pipe),
              [foo1, foo2]
      end.
 


### PR DESCRIPTION
1.0.3 changed riak_kv service to be marked up after primary vnodes are initialized and running, not after application was started.
