### PR TITLE
Fix race-condition around code loading.

### DIFF
--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -39,6 +39,7 @@ validate_module(Label, Module) when is_atom(Module) ->
         false ->
             case code:load_file(Module) of
                 {module, Module} -> ok;
+                {error, not_purged} -> ok;
                 {error, Error} ->
                     {error, io_lib:format(
                               "~s must be a valid module name"

--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -39,7 +39,17 @@ validate_module(Label, Module) when is_atom(Module) ->
         false ->
             case code:load_file(Module) of
                 {module, Module} -> ok;
-                {error, not_purged} -> ok;
+                {error, not_purged} ->
+                    %% In the case where identical pipes are started
+                    %% in parallel on a fresh node, they may race to
+                    %% reach the code:load_file(Module) call, meaning
+                    %% the loser will receive {error, not_purged}
+                    %% while the winner will receive {module,
+                    %% Module}. {error, not_purged} is ok because our
+                    %% goal is only to ensure that the module is
+                    %% loaded so we can verify the arity of the
+                    %% specified function.
+                    ok;
                 {error, Error} ->
                     {error, io_lib:format(
                               "~s must be a valid module name"


### PR DESCRIPTION
When parallel map-reduce jobs are invoked on a fresh node, they may try to invoke `code:load/1` at the same time, one of them receiving `{module, Module}` and one receiving `{error, not_purged}`, which bubbles back to the client through the error clause. Example error from riak_kv as seen in the [Ruby client builds](http://travis-ci.org/#!/basho/riak-ruby-client/jobs/596166/L50):

```
Phase {kvget_map,0}: module must be a valid module name (failed to load riak_kv_pipe_get: not_purged)
```

Since the code already being loaded is not an error, really, matching on the `not_purged` clause resolves this issue.
