### PR TITLE
Don't trigger archive behavior until handoff ?FOLD_REQ is received

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -484,7 +484,8 @@ handle_handoff_command(?FOLD_REQ{}=Cmd, Sender, State) ->
     handoff_cmd_internal(Cmd, Sender, State);
 handle_handoff_command(#cmd_archive{}=Cmd, _Sender, State) ->
     archive_internal(Cmd, State);
-handle_handoff_command(#cmd_enqueue{fitting=F}=Cmd, Sender, State) ->
+handle_handoff_command(#cmd_enqueue{fitting=F}=Cmd, Sender,
+                       #state{handoff=#handoff{}}=State) ->
     case worker_by_fitting(F, State) of
         {ok, _} ->
             %% not yet handed off: proceed
@@ -493,7 +494,8 @@ handle_handoff_command(#cmd_enqueue{fitting=F}=Cmd, Sender, State) ->
             %% handed off, or never existed: forward
             {forward, State}
     end;
-handle_handoff_command(#cmd_eoi{fitting=F}=Cmd, Sender, State) ->
+handle_handoff_command(#cmd_eoi{fitting=F}=Cmd, Sender,
+                       #state{handoff=#handoff{}}=State) ->
     case worker_by_fitting(F, State) of
         {ok, _} ->
             %% not yet handed off: proceed
@@ -504,7 +506,8 @@ handle_handoff_command(#cmd_eoi{fitting=F}=Cmd, Sender, State) ->
             send_done(F),
             {noreply, State}
     end;
-handle_handoff_command(#cmd_next_input{fitting=F}, _Sender, State) ->
+handle_handoff_command(#cmd_next_input{fitting=F}, _Sender,
+                       #state{handoff=#handoff{}}=State) ->
     %% force workers into waiting state so we can ask them to
     %% prepare for handoff
     {noreply, archive_fitting(F, State)};


### PR DESCRIPTION
Handoff startup is two steps: `Module:handoff_starting`, followed by receiving a `?FOLD_REQ` message.  It is possible for the vnode to receive messages from its workers and other processes between these two steps (thanks, Joe). We don't want to do handoff things until after the second message arrives, though.

This bug was detected by the dynamic cluster + MapReduce test.  It was possible for a vnode to have its `handoff_starting` function called, then receive a `next_input` request from one of its workers.  The vnode, thinking it was in handoff, would tell the worker to archive.  If the worker also finished and sent its archive back to the vnode before the `?FOLD_REQ` message arrived, a `bad_record` error would be raised in `riak_pipe_vnode:archive_internal/2`, because `#state.handoff` was the atom `starting`, as set by the `handoff_starting` function, instead of a `#handoff{}` record, as it is after the `?FOLD_REQ` message is received.  This fix prevents the whole mess by maintaining normal, non-handoff operation until `?FOLD_REQ` is received (so the response to `next_input` is the worker's next input, instead of the archive command).
