### PR TITLE
Fix invalid return value in riak_pipe_qcover_fsm

### DIFF
--- a/src/riak_pipe_qcover_fsm.erl
+++ b/src/riak_pipe_qcover_fsm.erl
@@ -65,8 +65,8 @@ process_results(ok, State) ->
     %% this 'done' means that the vnode that sent this reply is done,
     %% not that the entire request is done
     {done, State};
-process_results(Error, State) ->
-    {Error, State}.
+process_results({error, Reason}, _State) ->
+    {error, Reason}.
 
 finish({error, Reason}, #state{from={raw, Ref, Client}}=State) ->
     Client ! {Ref, {error, Reason}},


### PR DESCRIPTION
The `process_results` function in `riak_pipe_qcover_fsm` incorrectly returns `{{error, Reason}, State}` when it should return `{error, Reason}`. The qcover module implements a coverage FSM that is driven by `riak_core_coverage_fsm`, which passes the error from `process_results` to the `finish` function, which expects `{error, Reason}`. This problem manifests itself with the following match failure:

```
[error] <0.28297.0> CRASH REPORT Process <0.28297.0> with 2 neighbours crashed with reason: no function clause matching
  riak_pipe_qcover_fsm:finish({{error,worker_limit_reached},                                                           
                               {state,{raw,408228,<0.28284.0>}}},                                                      
                              {state,{raw,408228,<0.28284.0>}})                                                        
```
