### PR TITLE
Add support to log trace messages to existing sink

### DIFF
--- a/src/riak_pipe_log.erl
+++ b/src/riak_pipe_log.erl
@@ -44,6 +44,8 @@ log(#fitting_details{options=O, name=N}, Msg) ->
         sink ->
             Sink = proplists:get_value(sink, O),
             riak_pipe_sink:log(N, Sink, Msg);
+        {sink, Sink} ->
+            riak_pipe_sink:log(N, Sink, Msg);
         lager ->
             lager:info(
               "~s: ~P",


### PR DESCRIPTION
Listkeys and 2I and other input stages to map-reduce jobs are implemented as a separate pipe that sends results into a downstream map_reduce pipe. This change allows the listkeys/2I/etc pipes to specific an existing sink (eg. the mr pipe) as the target for error trace messages. This is necessary in order to send listkey/2I errors back to the client.
