### PR TITLE
avoid race to code:load_file by using code:ensure_loaded instead

### DIFF
--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -34,28 +34,13 @@
 %%      message).
 -spec validate_module(string(), term()) -> ok | {error, iolist()}.
 validate_module(Label, Module) when is_atom(Module) ->
-    case code:is_loaded(Module) of
-        {file, _} -> ok;
-        false ->
-            case code:load_file(Module) of
-                {module, Module} -> ok;
-                {error, not_purged} ->
-                    %% In the case where identical pipes are started
-                    %% in parallel on a fresh node, they may race to
-                    %% reach the code:load_file(Module) call, meaning
-                    %% the loser will receive {error, not_purged}
-                    %% while the winner will receive {module,
-                    %% Module}. {error, not_purged} is ok because our
-                    %% goal is only to ensure that the module is
-                    %% loaded so we can verify the arity of the
-                    %% specified function.
-                    ok;
-                {error, Error} ->
-                    {error, io_lib:format(
-                              "~s must be a valid module name"
-                              " (failed to load ~p: ~p)",
-                              [Label, Module, Error])}
-            end
+    case code:ensure_loaded(Module) of
+        {module, Module} -> ok;
+        {error, Error} ->
+            {error, io_lib:format(
+                      "~s must be a valid module name"
+                      " (failed to load ~p: ~p)",
+                      [Label, Module, Error])}
     end;
 validate_module(Label, Module) ->
     {error, io_lib:format("~s must be an atom, not a ~p",


### PR DESCRIPTION
It appears that R15B01 changed the triggers for when the "Module X must be purged before
loading" error is logged (as compared to R14B04).

As reported here: http://lists.basho.com/pipermail/riak-users_lists.basho.com/2012-July/008828.html

This patch should fix the issue by avoiding the race between the check on `is_loaded` and the call to `load_file`.
