### PR TITLE
Use ordsets instead of sets for log/trace filtering

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -733,7 +733,6 @@ dep_apps() ->
      syntax_tools,
      compiler,
      lager,
-     folsom,
      fun(start) ->
              _ = application:load(riak_core),
              [save_and_set_env(Triple) || Triple <- CoreEnvVars],

--- a/src/riak_pipe_sup.erl
+++ b/src/riak_pipe_sup.erl
@@ -62,6 +62,11 @@ start_link() ->
                          pos_integer()},
                         [ supervisor:child_spec() ]}}.
 init([]) ->
+    %% ordsets = enabled traces are represented as ordsets in fitting_details
+    %% sets = '' sets ''
+    riak_core_capability:register(
+      {riak_pipe, trace_format}, [ordsets, sets], sets),
+
     VMaster = {riak_pipe_vnode_master,
                {riak_core_vnode_master, start_link, [riak_pipe_vnode]},
                permanent, 5000, worker, [riak_core_vnode_master]},


### PR DESCRIPTION
Log and trace messages include a set of "tags", this allows them to be filtered by passing a list of "enabled tags" to the pipe's startup. Before this change, the tags were compared using the `sets` module. After this change, the tags are compared using the `ordsets` module. The `ordsets` module is much faster and generates less garbage for all current uses of log/trace filtering.

For example, `riak_kv_mrc_pipe` enables only the `error` tag. For a trace like `queue`, ordsets compares 

``` erlang
[error]
```

to

``` erlang
[Partition, node(), queue]
```

while sets compares

``` erlang
{set,1,16,16,8,80,48,
     {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
     {{[],[],[error],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}
```

to

``` erlang
{set,3,16,16,8,80,48,
     {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
     {{[],
       ['dev1@127.0.0.1'],
       [],
       [12345],
       [],
       [queue],
       [],[],[],[],[],[],[],[],[],[]}}}
```

the latter having been built dynamically for each log/trace message.

This patch decreases the runtime of a large MapReduce that @kellymclaughlin has been testing with by ~17% (from 35min to 29min). It also reduces the frequency of `long_gc` messages from the same query.

I've also removed `folsom` from the test startup code, so that Travis can actually run eunit on this branch.
