### PR TITLE
"Sink type" that can provide backpressure

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -162,10 +162,10 @@
 %%</dd<dt>
 %%      `{sink_type, Type}'
 %%</dt><dd>
-%%      Specifies the way in which result messages are delivered to
-%%      the sink. If `Type' is the atom `raw', results are delivered
-%%      as plain Erlang messages. If `Type' is the tuple `{fsm_sync,
-%%      Timeout}', results are delivered by calling {@link
+%%      Specifies the way in which messages are delivered to the
+%%      sink. If `Type' is the atom `raw', messages are delivered as
+%%      plain Erlang messages. If `Type' is the tuple `{fsm_sync,
+%%      Timeout}', messages are delivered by calling {@link
 %%      gen_fsm:sync_send_event/3} with the sink's pid, the result
 %%      message, and the specified timeout. If no `sink_type' option
 %%      is provided, `Type' defaults to `raw'.

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -390,7 +390,7 @@ forward_eoi(#state{details=Details}) ->
     ?T(Details, [eoi], {fitting, send_eoi}),
     case Details#fitting_details.output of
         #fitting{chashfun=sink}=Sink ->
-            riak_pipe_sink:eoi(Sink);
+            riak_pipe_sink:eoi(Sink, Details#fitting_details.options);
         #fitting{}=Fitting ->
             riak_pipe_fitting:eoi(Fitting)
     end.

--- a/src/riak_pipe_log.erl
+++ b/src/riak_pipe_log.erl
@@ -43,9 +43,9 @@ log(#fitting_details{options=O, name=N}, Msg) ->
             ok; %% no logging
         sink ->
             Sink = proplists:get_value(sink, O),
-            riak_pipe_sink:log(N, Sink, Msg);
+            riak_pipe_sink:log(N, Sink, Msg, O);
         {sink, Sink} ->
-            riak_pipe_sink:log(N, Sink, Msg);
+            riak_pipe_sink:log(N, Sink, Msg, O);
         lager ->
             lager:info(
               "~s: ~P",

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -25,30 +25,86 @@
 -module(riak_pipe_sink).
 
 -export([
-         result/3,
+         result/4,
          log/3,
-         eoi/1
+         eoi/1,
+         valid_sink_type/1
         ]).
 
 -include("riak_pipe.hrl").
 
+-export_type([sink_type/0]).
+-type sink_type() :: raw
+                   | {fsm_sync, Timeout::timeout()}.
+
 %% @doc Send a result to the sink (used by worker processes).  The
 %%      result is delivered as a `#pipe_result{}' record in the sink
 %%      process's mailbox.
--spec result(term(), Sink::riak_pipe:fitting(), term()) -> #pipe_result{}.
-result(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Output) ->
-    Pid ! #pipe_result{ref=Ref, from=From, result=Output}.
+-spec result(term(), Sink::riak_pipe:fitting(), term(),
+             riak_pipe:exec_opts()) ->
+         ok.
+result(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Output, Opts) ->
+    send_to_sink(Pid,
+                 #pipe_result{ref=Ref, from=From, result=Output},
+                 sink_type(Opts)).
 
 %% @doc Send a log message to the sink (used by worker processes and
 %%      fittings).  The message is delivered as a `#pipe_log{}' record
 %%      in the sink process's mailbox.
 -spec log(term(), Sink::riak_pipe:fitting(), term()) -> #pipe_log{}.
 log(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Msg) ->
-    Pid ! #pipe_log{ref=Ref, from=From, msg=Msg}.
+    send_to_sink(Pid, #pipe_log{ref=Ref, from=From, msg=Msg}, raw).
 
 %% @doc Send an end-of-inputs message to the sink (used by fittings).
 %%      The message is delivered as a `#pipe_eoi{}' record in the sink
 %%      process's mailbox.
 -spec eoi(Sink::riak_pipe:fitting()) -> #pipe_eoi{}.
 eoi(#fitting{pid=Pid, ref=Ref, chashfun=sink}) ->
-    Pid ! #pipe_eoi{ref=Ref}.
+    send_to_sink(Pid, #pipe_eoi{ref=Ref}, raw).
+
+%% @doc Learn the type of sink we're dealing with from the execution
+%% options.
+-spec sink_type(riak_pipe:exec_opts()) -> sink_type().
+sink_type(Opts) ->
+    case lists:keyfind(sink_type, 1, Opts) of
+        {_, Type} ->
+            Type;
+        false ->
+            raw
+    end.
+
+%% @doc Validate the type of sink given in the execution
+%% options. Returns `true' if the type is valid, or `{false, Type}' if
+%% invalid, where `Type' is what was found.
+-spec valid_sink_type(riak_pipe:exec_opts()) -> true | {false, term()}.
+valid_sink_type(Opts) ->
+    case lists:keyfind(sink_type, 1, Opts) of
+        {_, {fsm_sync, Timeout}} when is_integer(Timeout);
+                                      Timeout == infinity ->
+            true;
+        %% other types as needed (fsm_async, for example) can go here
+        {_, raw} ->
+            true;
+        false ->
+            true;
+        Other ->
+            {false, Other}
+    end.
+
+%% @doc Do the right kind of communication, given the sink type.
+-spec send_to_sink(pid(),
+                   #pipe_result{} | #pipe_log{} | #pipe_eoi{},
+                   sink_type()) ->
+         ok | {error, term()}.
+send_to_sink(Pid, Msg, raw) ->
+    Pid ! Msg,
+    ok;
+send_to_sink(Pid, Msg, {fsm_sync, Timeout}) ->
+    try
+        gen_fsm:sync_send_event(Pid, Msg, Timeout),
+        ok
+    catch
+        exit:{timeout,_} -> {error, timeout};
+        exit:{noproc,_}  -> {error, sink_died}
+    end.
+%% other types as needed (fsm_async, for example) can go here

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -26,8 +26,8 @@
 
 -export([
          result/4,
-         log/3,
-         eoi/1,
+         log/4,
+         eoi/2,
          valid_sink_type/1
         ]).
 
@@ -51,16 +51,18 @@ result(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Output, Opts) ->
 %% @doc Send a log message to the sink (used by worker processes and
 %%      fittings).  The message is delivered as a `#pipe_log{}' record
 %%      in the sink process's mailbox.
--spec log(term(), Sink::riak_pipe:fitting(), term()) -> #pipe_log{}.
-log(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Msg) ->
-    send_to_sink(Pid, #pipe_log{ref=Ref, from=From, msg=Msg}, raw).
+-spec log(term(), Sink::riak_pipe:fitting(), term(), list()) -> #pipe_log{}.
+log(From, #fitting{pid=Pid, ref=Ref, chashfun=sink}, Msg, Opts) ->
+    send_to_sink(Pid, #pipe_log{ref=Ref, from=From, msg=Msg},
+                 sink_type(Opts)).
 
 %% @doc Send an end-of-inputs message to the sink (used by fittings).
 %%      The message is delivered as a `#pipe_eoi{}' record in the sink
 %%      process's mailbox.
--spec eoi(Sink::riak_pipe:fitting()) -> #pipe_eoi{}.
-eoi(#fitting{pid=Pid, ref=Ref, chashfun=sink}) ->
-    send_to_sink(Pid, #pipe_eoi{ref=Ref}, raw).
+-spec eoi(Sink::riak_pipe:fitting(), list()) -> #pipe_eoi{}.
+eoi(#fitting{pid=Pid, ref=Ref, chashfun=sink}, Opts) ->
+    send_to_sink(Pid, #pipe_eoi{ref=Ref},
+                 sink_type(Opts)).
 
 %% @doc Learn the type of sink we're dealing with from the execution
 %% options.

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -105,7 +105,10 @@ send_to_sink(Pid, Msg, raw) ->
 send_to_sink(Pid, Msg, {fsm_sync, Period, Timeout}) ->
     case get(sink_sync) of
         undefined ->
-            send_to_sink_fsm(Pid, Msg, Timeout, 0 >= Period, 0);
+            %% never sync for an 'infinity' Period, but always sync
+            %% first send for any other Period, to prevent worker
+            %% restart from overwhelming the sink
+            send_to_sink_fsm(Pid, Msg, Timeout, Period /= infinity, 0);
         Count ->
             %% integer is never > than atom, so X is not > 'infinity'
             send_to_sink_fsm(Pid, Msg, Timeout, Count >= Period, Count)

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -35,7 +35,7 @@
 
 -export_type([sink_type/0]).
 -type sink_type() :: raw
-                   | {fsm_sync, Period::integer(), Timeout::timeout()}.
+                   | {fsm, Period::integer(), Timeout::timeout()}.
 
 %% @doc Send a result to the sink (used by worker processes).  The
 %%      result is delivered as a `#pipe_result{}' record in the sink
@@ -81,7 +81,7 @@ sink_type(Opts) ->
 -spec valid_sink_type(riak_pipe:exec_opts()) -> true | {false, term()}.
 valid_sink_type(Opts) ->
     case lists:keyfind(sink_type, 1, Opts) of
-        {_, {fsm_sync, Period, Timeout}}
+        {_, {fsm, Period, Timeout}}
           when (is_integer(Period) orelse Period == infinity),
               (is_integer(Timeout) orelse Timeout == infinity) ->
             true;
@@ -102,7 +102,7 @@ valid_sink_type(Opts) ->
 send_to_sink(Pid, Msg, raw) ->
     Pid ! Msg,
     ok;
-send_to_sink(Pid, Msg, {fsm_sync, Period, Timeout}) ->
+send_to_sink(Pid, Msg, {fsm, Period, Timeout}) ->
     case get(sink_sync) of
         undefined ->
             %% never sync for an 'infinity' Period, but always sync

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -287,13 +287,12 @@ send_output(Output, FromPartition, Details, FittingOverride, Timeout) ->
                   riak_core_apl:preflist()) ->
          ok | {error, term()}.
 send_output(Output, FromPartition,
-            #fitting_details{name=Name}=_Details,
+            #fitting_details{name=Name, options=Opts}=_Details,
             FittingOverride,
             Timeout, UsedPreflist) ->
     case FittingOverride#fitting.chashfun of
         sink ->
-            riak_pipe_sink:result(Name, FittingOverride, Output),
-            ok;
+            riak_pipe_sink:result(Name, FittingOverride, Output, Opts);
         follow ->
             %% TODO: should 'follow' use the original preflist (in
             %%       case of failover)?

--- a/src/riak_pipe_w_pass.erl
+++ b/src/riak_pipe_w_pass.erl
@@ -55,7 +55,7 @@ process(Input, _Last, #state{p=Partition, fd=FD}=State) ->
             {ok, State};
        true ->
             ?T(FD, [], {processing, Input}),
-            riak_pipe_vnode_worker:send_output(Input, Partition, FD),
+            ok = riak_pipe_vnode_worker:send_output(Input, Partition, FD),
             ?T(FD, [], {processed, Input}),
             {ok, State}
     end.

--- a/test/riak_pipe_test_sink_fsm.erl
+++ b/test/riak_pipe_test_sink_fsm.erl
@@ -26,7 +26,7 @@
 %%
 %% The FSM starts out in `acc' simply accumulating results and logs.
 %%
-%% If a `get_results' arrives during live, the FSM stores the `From',
+%% If a `get_results' arrives during `acc', the FSM stores the `From',
 %% and continues accumulating results/logs in `acc'.
 %%
 %% If an `eoi' comes in during `acc' before `get_results', the FSM

--- a/test/riak_pipe_test_sink_fsm.erl
+++ b/test/riak_pipe_test_sink_fsm.erl
@@ -1,0 +1,164 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Sink fsm for eunit tests. It accumulates all pipe results/logs
+%% until eoi, then delivers them to the caller of {@link
+%% get_results/1}.
+%%
+%% There are two states: `acc' and `wait'
+%%
+%% The FSM starts out in `acc' simply accumulating results and logs.
+%%
+%% If a `get_results' arrives during live, the FSM stores the `From',
+%% and continues accumulating results/logs in `acc'.
+%%
+%% If an `eoi' comes in during `acc' before `get_results', the FSM
+%% transitions to `wait', where it stops accumulating results/logs,
+%% and just waits for `get_results'.
+%%
+%% As soon as both `eoi' and `get_results' have arrived, the
+%% results/logs are delivered to the caller of {@link get_results/1},
+%% and the FSM exits.
+%%
+%% The sink can be told not to ack a list of `{FittingName, Output}'
+%% pairs, for testing purposes, by passing such a list as the value of
+%% a `skip_ack' property in the `Options' parameter of {@link
+%% start_link/2}. For example, to tell the sink not to ack the output
+%% `bar' from the fitting `foo':
+%%
+%% `riak_pipe_test_sink:start_link(PipeRef, [{skip_ack, [{foo,bar}]}])'
+%%
+%% The skipped output will still be added to the results list.
+-module(riak_pipe_test_sink_fsm).
+
+-behaviour(gen_fsm).
+
+%% API
+-export([start_link/1,
+         start_link/2,
+         get_results/1]).
+
+%% gen_fsm callbacks
+-export([init/1,
+         acc/2, acc/3,
+         wait/2, wait/3,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
+         code_change/4]).
+
+-include("riak_pipe.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+          ref,
+          opts,
+          from,
+          results,
+          logs
+               }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link(PipeRef) ->
+    start_link(PipeRef, []).
+
+start_link(PipeRef, Options) ->
+    gen_fsm:start_link(?MODULE, [PipeRef, Options], []).
+
+get_results(Sink) ->
+    gen_fsm:sync_send_event(Sink, get_results).
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+init([PipeRef, Opts]) ->
+    {ok, acc, #state{ref=PipeRef, opts=Opts, results=[], logs=[]}}.
+
+%% ACC: just accumulating
+%%   - #pipe_eoi{} -> eoi
+%%   - get_results -> respond
+acc(_, State) ->
+    {next_state, acc, State}.
+
+acc(#pipe_result{ref=Ref}=Result, _From, #state{ref=Ref}=State) ->
+    #pipe_result{from=F, result=R} = Result,
+    #state{results=Acc} = State,
+    NewState = State#state{results=[{F, R}|Acc]},
+    case should_skip_ack(F, R, State) of
+        true ->
+            {next_state, acc, NewState};
+        false ->
+            {reply, ok, acc, NewState}
+    end;
+acc(get_results, From, State) ->
+    {next_state, acc, State#state{from=From}}.
+
+%% WAIT: pipe ended, holding on for get_results
+%%   - get_results -> stop
+wait(_, State) ->
+    {next_state, wait, State}.
+wait(get_results, _From, State) ->
+    {stop, normal, results(State), State}.
+
+%% unused FSM bits
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+handle_info(#pipe_log{ref=Ref}=Log, acc, #state{ref=Ref}=State) ->
+    #pipe_log{from=F, msg=M} = Log,
+    #state{logs=Acc} = State,
+    {next_state, acc, State#state{logs=[{F, M}|Acc]}};
+handle_info(#pipe_eoi{ref=Ref}, acc, #state{ref=Ref}=State) ->
+    case State#state.from of
+        undefined ->
+            {next_state, wait, State};
+        From ->
+            gen_fsm:reply(From, results(State)),
+            {stop, normal, State}
+    end;
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+results(#state{results=Results, logs=Logs}) ->
+     {eoi, lists:reverse(Results), lists:reverse(Logs)}.    
+
+should_skip_ack(From, Result, #state{opts=Opts}) ->
+    SkipList = proplists:get_value(skip_ack, Opts, []),
+    lists:member({From, Result}, SkipList).


### PR DESCRIPTION
At the head of a pipe, and between its fittings, passing inputs/outputs is a blocking operation, which allows it to provide backpressure to keep downstream processes from being overwhelmed. Before this commit, there was no such behavior between the tail of the pipe and its sink. For very large Riak KV MapReduce jobs, it was common for the sink to become overwhelmed either with results or with log messages during failures.

This PR introduces blocking sink-delivery. It does this by providing the ability to specify the "type" of the sink, which indicates the method by which messages are delivered.

At this time there are two types:
- `raw`: The behavior that existed before this commit, and the default if none is specified. Messages are delivered by simply sending them to the sink process (`Sink ! Message.` in Erlang).
- `{fsm_sync, Timeout}`: Messages are delivered as synchronous `gen_fsm` events (`gen_fsm:sync_send_event(Sink, Message, Timeout)`).

The type is set in the `Options` parameter of `riak_pipe:exec/2` via the `sink_type` property: `riak_pipe:exec(Spec, [{sink_type, {fsm_sync, infinity}}|OtherOptions])`.

The spec of `riak_sink:*` has changed to facilitate error detection. Instead of returning the message it sent, it now returns the atom `ok` on success (always for `raw` sink types), or `{error, Reason}` for failure. Current `Reason`s are `timeout` if the request times out, and `sink_died` if the sink was gone before the call or vanished before replying.

New tests for this facility are in `riak_pipe:sink_type_test_/0`. A mock sink FSM for testing is included as `test/riak_pipe_test_sink_fsm.erl`.

Notes:
- Yes, synchronous delivery of each output is likely to introduce additional latency. This latency is likely more desirable than the alternative of unbounded memory consumption. There is also ongoing work (in the `bwf-pmi` branch) to deliver multiple outputs in a single message.
- Yes, synchronous log delivery is a hinderance to logging lots of messages. Again, it's likely more desirable than blowing up a sink with messages from many concurrent log producers. Additionally, the synchronicity is only encountered if the trace is actually delivered, and not if it is filtered out. Finally, the only current use of logging is in Riak KV's MapReduce, where it is used to deliver errors that cause the pipe to teardown immediately. Once one log is delivered there, the rate at which others can be delivered is not relevant.
- Synchronous delivery of the single eoi message seems unnecessary, but it makes the API more predictable.
