### PR TITLE
add opaque type exports as required for r16

### DIFF
--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -52,6 +52,7 @@
                 sinkmon :: reference()}). % monitor ref
 
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %%%===================================================================
 %%% API

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -62,7 +62,7 @@
 
 -opaque state() :: #state{}.
 
--export_type([details/0]).
+-export_type([details/0, state/0]).
 -type details() :: #fitting_details{}.
 
 %%%===================================================================

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -115,6 +115,7 @@
                          | #handoff{}}).
 
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 -record(cmd_enqueue, {fitting :: #fitting{},
                       input :: term(),

--- a/src/riak_pipe_vnode_worker.erl
+++ b/src/riak_pipe_vnode_worker.erl
@@ -161,6 +161,7 @@
                 vnode :: pid(),
                 modstate :: term()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Get information about this behavior.
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].

--- a/src/riak_pipe_w_crash.erl
+++ b/src/riak_pipe_w_crash.erl
@@ -33,6 +33,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% name of the table reMEMbering restarts
 -define(MEM, ?MODULE).

--- a/src/riak_pipe_w_fwd.erl
+++ b/src/riak_pipe_w_fwd.erl
@@ -35,6 +35,7 @@
 
 -record(state, {fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Initialization just stows the fitting details in the module's
 %%      state, for sending traces in {@link process/3}.

--- a/src/riak_pipe_w_pass.erl
+++ b/src/riak_pipe_w_pass.erl
@@ -35,6 +35,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Initialization just stows the partition and fitting details in
 %%      the module's state, for sending outputs in {@link process/3}.

--- a/src/riak_pipe_w_rec_countdown.erl
+++ b/src/riak_pipe_w_rec_countdown.erl
@@ -81,6 +81,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Initialization just stows the partition and fitting details in
 %%      the module's state, for sending outputs in {@link process/3}.

--- a/src/riak_pipe_w_reduce.erl
+++ b/src/riak_pipe_w_reduce.erl
@@ -93,6 +93,7 @@
                 p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Setup creates the store for evaluation results (a dict()) and
 %%      stashes away the `Partition' and `FittingDetails' for later.

--- a/src/riak_pipe_w_tee.erl
+++ b/src/riak_pipe_w_tee.erl
@@ -38,6 +38,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
 -spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->

--- a/src/riak_pipe_w_xform.erl
+++ b/src/riak_pipe_w_xform.erl
@@ -55,6 +55,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
 -spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->


### PR DESCRIPTION
These exports seem to be required for R16 to compile pipe.
