### PR TITLE
PULSE test & fix riak_pipe_fitting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REPO		?= riak_pipe
 RIAK_TAG	 = $(shell git describe --tags)
 REVISION	?= $(shell echo $(RIAK_TAG) | sed -e 's/^$(REPO)-//')
 PKG_VERSION	?= $(shell echo $(REVISION) | tr - .)
+PULSE_TESTS	 = reduce_fitting_pulse
 
 .PHONY: deps
 
@@ -21,6 +22,12 @@ distclean: clean ballclean
 
 test: all
 	./rebar skip_deps=true eunit
+
+# You should 'clean' before your first run of this target
+# so that deps get built with PULSE where needed.
+pulse:
+	./rebar compile -D PULSE
+	./rebar eunit -D PULSE skip_deps=true suite=$(PULSE_TESTS)
 
 docs:
 	./rebar skip_deps=true doc

--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -46,6 +46,14 @@
 -include("riak_pipe.hrl").
 -include("riak_pipe_debug.hrl").
 
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_replace_module,[{gen_fsm,pulse_gen_fsm}]}).
+-endif.
+
 -record(state, {options :: riak_pipe:exec_opts(),
                 pipe :: #pipe{},
                 alive :: [{#fitting{}, reference()}], % monitor ref

--- a/src/riak_pipe_builder_sup.erl
+++ b/src/riak_pipe_builder_sup.erl
@@ -38,6 +38,14 @@
 
 -include("riak_pipe.hrl").
 
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_replace_module,[{supervisor,pulse_supervisor}]}).
+-endif.
+
 -define(SERVER, ?MODULE).
 
 %%%===================================================================

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -52,6 +52,14 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_replace_module,[{gen_fsm,pulse_gen_fsm}]}).
+-endif.
+
 -record(worker, {partition :: riak_pipe_vnode:partition(),
                  pid :: pid(),
                  monitor :: reference()}).

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -134,7 +134,14 @@ send_to_sink_fsm(Pid, Msg, Timeout, true, _Count) ->
         put(sink_sync, 0),
         ok
     catch
-        exit:{timeout,_} -> {error, timeout};
-        exit:{noproc,_}  -> {error, sink_died}
+        exit:{timeout,_} ->
+            {error, timeout};
+        exit:{_Reason,{gen_fsm,sync_send_event,_}} ->
+            %% we don't care why it died, just that it did ('noproc'
+            %% and 'normal' have been seen; others could be possible)
+            {error, sink_died};
+        exit:{_Reason,{pulse_gen_fsm,sync_send_event,_}} ->
+            %% the pulse parse transform won't catch just the atom 'gen_fsm'
+            {error, sink_died}
     end.
 

--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -33,6 +33,14 @@
 
 -include("riak_pipe.hrl").
 
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_replace_module,[{gen_fsm,pulse_gen_fsm}]}).
+-endif.
+
 -export_type([sink_type/0]).
 -type sink_type() :: raw
                    | {fsm, Period::integer(), Timeout::timeout()}.

--- a/test/reduce_fitting_pulse_sink.erl
+++ b/test/reduce_fitting_pulse_sink.erl
@@ -1,0 +1,127 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Support module for reduce_fitting_pulse tests - implements a
+%% pipe fsm-style sink.
+-module(reduce_fitting_pulse_sink).
+
+-compile(export_all).
+%% compiler gets angry if behavior functions are not exported explicitly
+-export([init/1,handle_event/3,handle_sync_event/4,terminate/3,
+         handle_info/3,code_change/4]).
+
+-ifdef(PULSE).
+-include_lib("pulse/include/pulse.hrl").
+%% have to transform the 'receive' of the work results
+-compile({parse_transform, pulse_instrument}).
+%% don't trasnform toplevel test functions
+-compile({pulse_replace_module,[{gen_fsm,pulse_gen_fsm}]}).
+-endif.
+
+-include("riak_pipe.hrl").
+
+-behaviour(gen_fsm).
+
+-record(state, {monitor, owner, ref, builder, results=[], logs=[], waiter}).
+
+start_link(Owner, Ref) ->
+    gen_fsm:start_link(?MODULE, [Owner, Ref], []).
+
+use_pipe(Sink, Ref, Pipe) ->
+    gen_fsm:sync_send_event(Sink, {use_pipe, Ref, Pipe}, infinity).
+
+all_results(Sink, Ref) ->
+    gen_fsm:sync_send_event(Sink, {all_results, Ref}, infinity).
+
+init([Owner, Ref]) ->
+    Monitor = erlang:monitor(process, Owner),
+    {ok,
+     wait_pipe,
+     #state{monitor=Monitor, owner=Owner, ref=Ref}}.
+
+wait_pipe({use_pipe, Ref, #pipe{builder=Builder}},
+          _From,
+          #state{ref=Ref}=State) ->
+    Monitor = erlang:monitor(process, Builder),
+    {reply,
+     ok,
+     accumulating,
+     State#state{builder={Monitor, Builder}}}.
+
+accumulating(#pipe_result{ref=Ref}=R,
+             #state{ref=Ref, results=Results}=State) ->
+    {next_state, accumulating, State#state{results=[R|Results]}};
+accumulating(#pipe_log{ref=Ref}=L,
+             #state{ref=Ref, logs=Logs}=State) ->
+    {next_state, accumulating, State#state{logs=[L|Logs]}};
+accumulating(#pipe_eoi{ref=Ref},
+             #state{ref=Ref, waiter=Waiter}=State) ->
+    case Waiter of
+        undefined ->
+            {next_state, waiting, State};
+        _ ->
+            gen_fsm:reply(Waiter, State#state.results),
+            {stop, normal, State}
+    end.
+
+accumulating({all_results, Ref}, From, #state{ref=Ref}=State) ->
+    {next_state, accumulating, State#state{waiter=From}};
+accumulating(Other, _From, State) ->
+    case accumulating(Other, State) of
+        {next_state, NextStateName, NextState} ->
+            {reply, ok, NextStateName, NextState};
+        {stop, Reason, State} ->
+            {stop, Reason, ok, State};
+        Response ->
+            Response
+    end.
+
+waiting({all_results, Ref},
+        _From,
+        #state{ref=Ref, results=Results}=State) ->
+    {stop, normal, Results, State}.
+
+handle_info({'DOWN', Monitor, process, Owner, _Reason},
+            _StateName,
+            #state{monitor=Monitor, owner=Owner}=State) ->
+    {stop, normal, State};
+handle_info({'DOWN', Monitor, process, Builder, Reason},
+            StateName,
+            #state{builder={Monitor, Builder}}=State) ->
+    case Reason of
+        normal ->
+            %% mimicking riak_kv_mrc_sink for the moment
+            {next_state, StateName, State};
+        _ ->
+            %% also mimicking riak_kv_mrc_sink
+            {stop, normal, State}
+    end.
+
+handle_event(_, _, State) ->
+    {stop, unknown_message, State}.
+
+handle_sync_event(_, _, _, State) ->
+    {stop, unknown_message, State}.
+
+code_change(_Old, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.


### PR DESCRIPTION
In an attempt to locate the source of `noproc` messages in issues 48 and 49, I wrote the attached tests to exercise part `riak_pipe_fitting` under PULSE. The specific part I was targeting was the 'eoi' behavior encountered when no workers are active. To facilitate Riak KV's mapreduce need to evaluate a reduce phase even if no inputs are received, `riak_pipe_fitting` will evaluate the worker behavior in-process in this case.

The PULSE test found that in addition to a `noproc` exit when sending synchronous messages to a sink that does not exists, `normal` (or any other reason) exits may happen if the sink exits _after_ the synchronous message has been delivered. The `riak_pipe_sink:send_to_sink_fsm/5` function has been changed to catch these other exit reasons as well.

To see the tests fail, checkout the first (and second, if you wish) commits in this PR, and run `./rebar get-deps && make clean pulse` They should fail with a reason like (partial Eunit output):

```
    {function_clause,
        [{reduce_fitting_pulse,exit_reason_is_normalish,
             [{normal,
                  {pulse_gen_fsm,sync_send_event,
                      [<0.700.0>,{p">>...
```

And may also include:

```
Exit Reasons: [{client,after_eoi},
               {sink,normal},
               {fitting,
                   {normal,
                       {pulse_gen_fsm,sync_send_event,
                           [<0.675.0>,
                            {pipe_eoi,#Ref<0.0.0.11121>},
                            infinity]}}},
               {builder,normal}]
```

And:

```
::error:{assertion_failed,[{module,reduce_fitting_pulse},
                         {line,299},
                         {expression,"eqc : quickcheck ( eqc : numtests ( 5000 , prop_fitting_dies_normal ( ) ) )"},
                         {expected,true},
                         {value,false}]}
  in function reduce_fitting_pulse:'-death_test_/0-fun-2-'/0 [test/reduce_fitting_pulse.erl:299]
```

If they instead fail for a reason like `timeout`, you may be missing the [pulse_otp](https://github.com/Quviq/pulse_otp) package, or other PULSE components.

To see the tests pass, aadd third (and fourth, if you wish) commit to your checkout, and `make pulse` again.
