### PR TITLE
Backport fix in issue 73 to 1.3 branch

### DIFF
--- a/src/riak_pipe_sink.erl
+++ b/src/riak_pipe_sink.erl
@@ -126,7 +126,14 @@ send_to_sink_fsm(Pid, Msg, Timeout, true, _Count) ->
         put(sink_sync, 0),
         ok
     catch
-        exit:{timeout,_} -> {error, timeout};
-        exit:{noproc,_}  -> {error, sink_died}
+        exit:{timeout,_} ->
+            {error, timeout};
+        exit:{_Reason,{gen_fsm,sync_send_event,_}} ->
+            %% we don't care why it died, just that it did ('noproc'
+            %% and 'normal' have been seen; others could be possible)
+            {error, sink_died};
+        exit:{_Reason,{pulse_gen_fsm,sync_send_event,_}} ->
+            %% the pulse parse transform won't catch just the atom 'gen_fsm'
+            {error, sink_died}
     end.
 


### PR DESCRIPTION
It was desired to have the sink-sync-send crash fix backported to the 1.3 branch. This is a cherry-pick of commit 041cee5, which fixed the issue in pull request #73. The tests tests that demonstrate the issue have not been backported, to save merge hassle. To run the tests, cherry-pick the other commits from #73 (you'll have to resolve a minor conflict in `riak_pipe_fitting.erl`, to make sure that the PULSE includes are added).
