### PR TITLE
lower "fitting was gone" log to debug level

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -790,9 +790,8 @@ new_worker(Fitting, #state{partition=P, worker_sup=Sup, worker_q_limit=WQL}) ->
                              blocking=queue:new(),
                              perf=Perf}};
             gone ->
-                lager:error(
-                  "Pipe worker startup failed:"
-                  "fitting was gone before startup"),
+                lager:debug(
+                  "Fitting was gone before pipe worker startup"),
                 worker_startup_failed
         end
     catch Type:Reason ->


### PR DESCRIPTION
Issue #50 is not the only complaint about the message,
"Pipe worker startup failed:fitting was gone before startup".
It's not an important message, though. It _might_ tell you that a
pipe vnode is lagging a bit, but most often it's just noise about
pipes that shut down for other reasons (MapReduce errors).

This commit lowers the log level of the message to 'debug' and
rewords it, since it really has nothing to do with the worker
failing to start.
