### PR TITLE
limited support for ring resizing

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -113,7 +113,7 @@
                 worker_q_limit :: pos_integer(),
                 workers_archiving :: [#worker{}],
                 handoff :: undefined | starting | cancelled | finished
-                         | #handoff{}}).
+                         | resize | #handoff{}}).
 
 -opaque state() :: #state{}.
 -export_type([state/0]).


### PR DESCRIPTION
Provides ability for clusters using riak_pipe to use ring
resizing. Ultimately, this is a hack that includes just enough support
for clusters to successfully transition between the old and new ring
without riak_pipe getting in the way. It does this by lying to
riak_core's handoff subsystem during resize. The lie it tells is that
even when it has outstanding work/queue items it will report that it
is empty. This will allow the pipe vnode to continue processing work
in the old ring since vnodes are not deleted and shutdown until the
new ring is installed. This does, however, come with the drawback that
work that is in-flight when the new ring is installed has undefined
behaviour. The work may complete or may be terminated by the cleanup
processes that follows the installation of the new ring.

Better support for pipe has several challenges. Some can be easily
addressed through extra support in riak_core but the fundamental
challenge is that riak_pipe hands off worker ~~archives~~ queues. In a larger or
smaller ring parts of those ~~archrives~~ queues would be owned by new
partitions which would force ~~those archives~~ queues to be ~~"re-opened" and~~
disseminated to multiple targets during handoff.
