### PR TITLE
Integrate the Exometer metrics package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {edoc_opts, [{preprocess, true}]}.
 {cover_enabled, true}.
 {deps, [
-       {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {edoc_opts, [{preprocess, true}]}.
 {cover_enabled, true}.
 {deps, [
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+       {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
        ]}.

--- a/src/riak_pipe_stat.erl
+++ b/src/riak_pipe_stat.erl
@@ -25,7 +25,6 @@
 %% API
 -export([start_link /0, register_stats/0,
          get_stats/0,
-         produce_stats/0,
          update/1,
          stats/0]).
 
@@ -35,6 +34,7 @@
 
 -define(SERVER, ?MODULE).
 -define(APP, riak_pipe).
+-define(PFX, riak_core_stat:prefix()).
 
 -type stat_type() :: counter | spiral.
 
@@ -46,24 +46,12 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    _ = [begin
-	     StatName = stat_name(Name),
-	     (catch exometer_entry:delete(StatName)),
-	     register_stat(StatName, Type)
-	 end || {Name, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
-    case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats, _TS} ->
-            Stats;
-        Error -> Error
-    end.
-
-produce_stats() ->
-    {?APP, riak_core_stat_q:get_stats([riak_pipe])}.
+    riak_core_stat:get_stats(?APP).
 
 update(Arg) ->
     gen_server:cast(?SERVER, {update, Arg}).
@@ -102,12 +90,12 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec do_update(term()) -> ok.
 do_update(create) ->
-    exometer_entry:update([?APP, pipeline, create], 1),
-    exometer_entry:update([?APP, pipeline, active], 1);
+    exometer:update([?PFX, ?APP, pipeline, create], 1),
+    exometer:update([?PFX, ?APP, pipeline, active], 1);
 do_update(create_error) ->
-    exometer_entry:update([?APP, pipeline, create, error], 1);
+    exometer:update([?PFX, ?APP, pipeline, create, error], 1);
 do_update(destroy) ->
-    exometer_entry:update([?APP, pipeline, active], -1).
+    exometer:update([?PFX, ?APP, pipeline, active], -1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -119,14 +107,3 @@ stats() ->
      {[pipeline, create, error], spiral},
      {[pipeline, active], counter}
     ].
-
--spec stat_name(riak_core_stat_q:path()) -> riak_core_stat_q:stat_name().
-stat_name(Name) when is_tuple(Name) ->
-    [?APP | tuple_to_list(Name)];
-stat_name(Name) when is_list(Name) ->
-    [?APP | Name].
-
--spec register_stat(riak_core_stat_q:stat_name(), stat_type()) -> 
-         ok | {error, Subject :: term(), Reason :: term()}.
-register_stat(Name, Type) ->
-    exometer_entry:new(Name, Type).


### PR DESCRIPTION
This PR is part of a set of PRs aimed at integrating the [Exometer](https://github.com/Feuerlabs/exometer) metrics package into Riak.

(From basho/riak_core#465)

From our measurements so far, Exometer offers both better throughput and lower footprint than the previous metrics management, and at the same time offers more flexible and uniform handling and better extensibility.

In addition to maintaining the console command `riak-admin status` and the HTTP JSON report (which aim to be backwards-compatible), a new console command, `riak-admin stat <cmd>` has been added, for selective reporting of statistics as well as some management (ability to enable/disable metrics on the fly).

Other noteworthy changes:
- Exometer entry names are always lists. In riak, only atoms and numbers should be used as list elements.
- A top-level 'prefix' (default: `riak`) has been added, in order to differentiate between stats from different riak-style products (e.g. when reporting stats to collectd). The function `riak_core_stat:prefix()` is generated as a constant expression through the parse transform `riak_core_stat_xform`, which in its turn checks the OS env variable `RIAK_CORE_STAT_PREFIX`. A typical entry would thus be e.g. `[riak,riak_kv,node,gets,siblings]`.
- Internally in riak, stats are referred to symbolically using the same (tuple-based) names as before. These often refer to more than one low-level metric, so it seemed reasonable to keep this naming scheme.
- Exometer provides similar functionality as 'sidejob' and the riak_core stat cache, so these are no longer used for stats management (although sidejob still maintains some stats on its own, which are accessible via Exometer). Other apps still register with `riak_core_stat`, but need not provide callbacks in other to query the stats. The query style of exometer is the same as that of riak_core_stat.
