### PR TITLE
Feuerlabs stat combo

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {edoc_opts, [{preprocess, true}]}.
 {cover_enabled, true}.
 {deps, [
-       {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {edoc_opts, [{preprocess, true}]}.
 {cover_enabled, true}.
 {deps, [
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+       {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {edoc_opts, [{preprocess, true}]}.
 {cover_enabled, true}.
 {deps, [
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-stat-combo"}}}
        ]}.

--- a/src/riak_pipe_stat.erl
+++ b/src/riak_pipe_stat.erl
@@ -25,6 +25,7 @@
 %% API
 -export([start_link /0, register_stats/0,
          get_stats/0,
+         produce_stats/0,
          update/1,
          stats/0]).
 
@@ -46,12 +47,42 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
+    case riak_core_stat:stat_system() of
+        legacy   -> register_stats_legacy();
+        exometer -> register_stats_exometer()
+    end.
+
+register_stats_legacy() ->
+    _ = [begin
+             StatName = stat_name(Name),
+             (catch folsom_metrics:delete_metric(StatName)),
+             ok = register_stat(StatName, Type)
+         end || {Name, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+
+register_stats_exometer() ->
     riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
+    case riak_core_stat:stat_system() of
+        legacy   -> get_stats_legacy();
+        exometer -> get_stats_exometer()
+    end.
+
+get_stats_legacy() ->
+    case riak_core_stat_cache:get_stats(?APP) of
+        {ok, Stats, _TS} ->
+            Stats;
+        Error -> Error
+    end.
+
+get_stats_exometer() ->
     riak_core_stat:get_stats(?APP).
+
+produce_stats() ->
+    {?APP, riak_core_stat_q:get_stats([riak_pipe])}.
 
 update(Arg) ->
     gen_server:cast(?SERVER, {update, Arg}).
@@ -89,12 +120,26 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc Update the given `Stat'.
 -spec do_update(term()) -> ok.
-do_update(create) ->
+do_update(Arg) ->
+    case riak_core_stat:stat_system() of
+        legacy   -> do_update_legacy(Arg);
+        exometer -> do_update_exometer(Arg)
+    end.
+
+do_update_legacy(create) ->
+    ok = folsom_metrics:notify_existing_metric({?APP, pipeline, create}, 1, spiral),
+    ok = folsom_metrics:notify_existing_metric({?APP, pipeline, active}, {inc, 1}, counter);
+do_update_legacy(create_error) ->
+    ok = folsom_metrics:notify_existing_metric({?APP, pipeline, create, error}, 1, spiral);
+do_update_legacy(destroy) ->
+    ok = folsom_metrics:notify_existing_metric({?APP, pipeline, active}, {dec, 1}, counter).
+
+do_update_exometer(create) ->
     exometer:update([?PFX, ?APP, pipeline, create], 1),
     exometer:update([?PFX, ?APP, pipeline, active], 1);
-do_update(create_error) ->
+do_update_exometer(create_error) ->
     exometer:update([?PFX, ?APP, pipeline, create, error], 1);
-do_update(destroy) ->
+do_update_exometer(destroy) ->
     exometer:update([?PFX, ?APP, pipeline, active], -1).
 
 %% -------------------------------------------------------------------
@@ -107,3 +152,14 @@ stats() ->
      {[pipeline, create, error], spiral},
      {[pipeline, active], counter}
     ].
+
+-spec stat_name(riak_core_stat_q:path()) -> riak_core_stat_q:stat_name().
+stat_name(Name) when is_list(Name) ->
+    list_to_tuple([?APP] ++ Name).
+
+-spec register_stat(riak_core_stat_q:stat_name(), stat_type()) -> 
+         ok | {error, Subject :: term(), Reason :: term()}.
+register_stat(Name, spiral) ->
+    folsom_metrics:new_spiral(Name);
+register_stat(Name, counter) ->
+    folsom_metrics:new_counter(Name).

--- a/src/riak_pipe_stat.erl
+++ b/src/riak_pipe_stat.erl
@@ -25,7 +25,6 @@
 %% API
 -export([start_link /0, register_stats/0,
          get_stats/0,
-         produce_stats/0,
          update/1,
          stats/0]).
 
@@ -35,6 +34,7 @@
 
 -define(SERVER, ?MODULE).
 -define(APP, riak_pipe).
+-define(PFX, riak_core_stat:prefix()).
 
 -type stat_type() :: counter | spiral.
 
@@ -46,24 +46,12 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    _ = [begin
-	     StatName = stat_name(Name),
-	     (catch exometer_entry:delete(StatName)),
-	     register_stat(StatName, Type)
-	 end || {Name, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
-    case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats, _TS} ->
-            Stats;
-        Error -> Error
-    end.
-
-produce_stats() ->
-    {?APP, riak_core_stat_q:get_stats([riak_pipe])}.
+    riak_core_stat:get_stats(?APP).
 
 update(Arg) ->
     gen_server:cast(?SERVER, {update, Arg}).
@@ -102,12 +90,12 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec do_update(term()) -> ok.
 do_update(create) ->
-    exometer_entry:update([?APP, pipeline, create], 1),
-    exometer_entry:update([?APP, pipeline, active], 1);
+    exometer:update([?PFX, ?APP, pipeline, create], 1),
+    exometer:update([?PFX, ?APP, pipeline, active], 1);
 do_update(create_error) ->
-    exometer_entry:update([?APP, pipeline, create, error], 1);
+    exometer:update([?PFX, ?APP, pipeline, create, error], 1);
 do_update(destroy) ->
-    exometer_entry:update([?APP, pipeline, active], -1).
+    exometer:update([?PFX, ?APP, pipeline, active], -1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -119,14 +107,3 @@ stats() ->
      {[pipeline, create, error], spiral},
      {[pipeline, active], counter}
     ].
-
--spec stat_name(riak_core_stat_q:path()) -> riak_core_stat_q:stat_name().
-stat_name(Name) when is_tuple(Name) ->
-    [?APP | tuple_to_list(Name)];
-stat_name(Name) when is_list(Name) ->
-    [?APP | Name].
-
--spec register_stat(riak_core_stat_q:stat_name(), stat_type()) -> 
-         ok | {error, Subject :: term(), Reason :: term()}.
-register_stat(Name, Type) ->
-    exometer_entry:new(Name, Type).


### PR DESCRIPTION
See [riak_core PR 487](https://github.com/basho/riak_core/pull/487):

The function identifying which system is used is riak_core_stat:stat_system(). This function is hard-coded to 'exometer', but can be changed to 'legacy' by setting the OS environment variable RIAK_CORE_STAT_SYSTEM to "legacy", and ensuring that the module riak_core_stat.erl is recompiled.
