### PR TITLE
rpc:call try/catch rex

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -428,11 +428,14 @@ active_pipelines(global) ->
     [ {Node, active_pipelines(Node)}
       || Node <- riak_core_node_watcher:nodes(riak_pipe) ];
 active_pipelines(Node) when is_atom(Node) ->
-    case rpc:call(Node, riak_pipe_builder_sup, pipelines, []) of
-        {badrpc, _}=Reason ->
-            {error, Reason};
+    try rpc:call(Node, riak_pipe_builder_sup, pipelines, []) of
+        {badrpc, _} ->
+            error;
         Pipes ->
             Pipes
+    catch
+        _:_ ->
+            error
     end.
 
 %% @doc Retrieve details about the status of the workers in this
@@ -458,7 +461,7 @@ status(#pipe{fittings=Fittings}) ->
     WorkerFittings = invert_dict(fun(_K, V) -> V end,
                                  fun(K, _V) -> K end,
                                  dict:from_list(FittingWorkers)),
-    
+
     %% grab all worker-fitting statuses at once
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     WorkerStatuses = dict:map(worker_status(Ring), WorkerFittings),
@@ -530,16 +533,21 @@ worker_status(Ring) ->
     fun(Partition, Fittings) ->
             %% lookup vnode pid
             Node = riak_core_ring:index_owner(Ring, Partition),
-            {ok, Vnode} = rpc:call(Node,
-                                   riak_core_vnode_master, get_vnode_pid,
-                                   [Partition, riak_pipe_vnode]),
-            
-            %% get status of each worker
-            {Partition, Workers} = riak_pipe_vnode:status(Vnode, Fittings),
+            try rpc:call(Node, riak_core_vnode_master, get_vnode_pid,
+                               [Partition, riak_pipe_vnode]) of
+                {badrpc, _} = Error ->
+                    [{node, Node}, {partition, Partition}, {error, Error}];
+                {ok, Vnode} ->
+                    %% get status of each worker
+                    {Partition, Workers} = riak_pipe_vnode:status(Vnode, Fittings),
 
-            %% add 'node' and 'partition' to status
-            [ [{node, Node}, {partition, Partition} | W]
-              || W <- Workers ]
+                    %% add 'node' and 'partition' to status
+                    [ [{node, Node}, {partition, Partition} | W]
+                        || W <- Workers ]
+            catch
+                _:_ = Error ->
+                    [{node, Node}, {partition, Partition}, {error, Error}]
+            end
     end.
 
 %% @doc An example run of a simple pipe.  Uses {@link example_start/0},

--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -369,6 +369,12 @@ queue_work_wait(Ref, Index, VnodePid) ->
                    end,
             %% monitor new vnode, since the input will be handled
             %% there, instead of at the vnode originally contacted
+
+            %% On review of this code path, while it's possible
+            %% rpc:call can return {badrpc, _} or throw an error
+            %% exit:_, the supervision tree for riak_pipe_vnode will
+            %% not try and restart the process, so a crash in this
+            %% case is safe.
             {ok, NextPid} = rpc:call(Next,
                                      riak_core_vnode_master,
                                      get_vnode_pid,


### PR DESCRIPTION
```
/Users/joe/dev/basho/riak_ee/deps/riak_pipe/src/riak_pipe.erl:
  429        || Node <- riak_core_node_watcher:nodes(riak_pipe) ];
  430  active_pipelines(Node) when is_atom(Node) ->
  431:     case rpc:call(Node, riak_pipe_builder_sup, pipelines, []) of
  432          {badrpc, _}=Reason ->
  433              {error, Reason};
  ...
  531              %% lookup vnode pid
  532              Node = riak_core_ring:index_owner(Ring, Partition),
  533:             {ok, Vnode} = rpc:call(Node,
  534                                     riak_core_vnode_master, get_vnode_pid,
  535                                     [Partition, riak_pipe_vnode]),

/Users/joe/dev/basho/riak_ee/deps/riak_pipe/src/riak_pipe_vnode.erl:
  370              %% monitor new vnode, since the input will be handled
  371              %% there, instead of at the vnode originally contacted
  372:             {ok, NextPid} = rpc:call(Next,
  373                                       riak_core_vnode_master,
  374                                       get_vnode_pid,
```
