### PR TITLE
Remove afunix from EXOMETER_PACKAGES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REVISION	?= $(shell echo $(RIAK_TAG) | sed -e 's/^$(REPO)-//')
 PKG_VERSION	?= $(shell echo $(REVISION) | tr - .)
 PULSE_TESTS	 = reduce_fitting_pulse
 
-EXOMETER_PACKAGES = "(basic), +afunix"
+EXOMETER_PACKAGES = "(basic)"
 export EXOMETER_PACKAGES
 
 .PHONY: deps


### PR DESCRIPTION
Afunix is not used at this time, and may cause build issues on some
platforms.
