### PR TITLE
Add log message to probe ambigious error

### DIFF
--- a/src/riak_pipe_builder.erl
+++ b/src/riak_pipe_builder.erl
@@ -199,6 +199,12 @@ handle_info({'DOWN', Ref, process, Pid, Reason}, StateName,
     case lists:keytake(Ref, 2, Alive) of
         {value, {#fitting{pid=Pid}, Ref}, Rest} ->
             %% one of our fittings died
+            case Reason of
+                normal -> ok;
+                _ ->
+                    lager:warning("~p: Fitting worker ~p died. Reason: ~p",
+                                  [StateName, Pid, Reason])
+            end,
             maybe_shutdown(Reason,
                            StateName,
                            State#state{alive=Rest});


### PR DESCRIPTION
This patch adds a log message line when pipe fitting died and MapReduce failed with ambiguous error. This is also a probe when a customer issue (zd://9291) reproduced.
