### PR TITLE
Update dependencies for develop branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,5 +7,5 @@
 {xref_checks, []}.
 {xref_queries, [{"(XC - UC) || (XU - X - B - cluster_info : Mod)", []}]}.
 {deps, [
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.1"}}}
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
        ]}.


### PR DESCRIPTION
The dependency on riak_core was set to `{tag, "2.1.1"}`, which was causing version conflicts, so update to `{branch, "develop"}` instead.
