### PR TITLE
Correct exec_option() typespec for log

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -97,7 +97,7 @@
 -type exec_option() :: {sink, fitting()}
                      | {sink_type, riak_pipe_sink:sink_type()}
                      | {trace, list() | riak_pipe_log:trace_filter()}
-                     | {log, sink | sasl}.
+                     | {log, sink | {sink, term()} | lager | sasl}.
 -type stat() :: {atom(), term()}.
 
 %% @doc Setup a pipeline.  This function starts up fitting/monitoring


### PR DESCRIPTION
Originally by Paul Oliver puzza007@gmail.com.  Hand-picked from
https://github.com/puzza007/riak_pipe/commit/d03daf7d2; needed to kill
off some dialyzer issues in riak_kv (part of https://github.com/basho/riak_kv/pull/1268).
