### PR TITLE
Bugfix/listkeys filters

### DIFF
--- a/src/riak_pipe_qcover_fsm.erl
+++ b/src/riak_pipe_qcover_fsm.erl
@@ -59,7 +59,7 @@ init(From, [#pipe{fittings=[{_Name, Fitting}|_]}, Input, NVal]) ->
      riak_pipe,              %% NodeCheckService
      riak_pipe_vnode_master, %% VNodeMaster
      infinity,               %% Timeout
-     riak_core_coverage_plan, %% Module for coverage plans
+     fun riak_core_coverage_plan:create_plan/6, %% Function for creating coverage plans
      #state{from=From}}.     %% State
 
 process_results(ok, State) ->


### PR DESCRIPTION
**Context**

stream_list_keys has always returned inconsistent results when used with TS data.  I've tracked this down to the coverage filter functions that are applied during the fold over keys on a vnode.  These filters check whether a key should be included, by checking if its hash falls within a specified hash range for a vnode.  These filters are applied to the storage keys in leveldb.  For TS, however, these filters need to be applied not to the storage key (which is the local key), but instead to the partition key, which can be derived from the local key by an appropriate transformation.

This PR addresses this inconsistency by changing the filter functions to use a key conversion function on the storage key prior to hashing. It is one of three PRs: riak_kv (https://github.com/basho/riak_kv/pull/1404), riak_core (https://github.com/basho/riak_core/pull/834) and riak_pipe (https://github.com/basho/riak_pipe/pull/105).  For reference, I include my diagram of the listkeys code path here:

 ![RiakTS Listkeys Path](https://gist.githubusercontent.com/erikleitch/8191db35b09bc8357df4/raw/69e7510c9233ecc3e35fd78a12807df6fab5514d/tslistkeys.png)

**Changes in this repo**
- **riak_pipe_qcover_fsm.erl**<br>
  - Because riak_core_coverage_fsm now expects a plan fn rather than a plan mod, init functions for this module has also been modified to return a plan fun
