### PR TITLE
Handle noproc errors correctly in queue_work_wait

### DIFF
--- a/src/riak_pipe_vnode.erl
+++ b/src/riak_pipe_vnode.erl
@@ -354,7 +354,7 @@ queue_work_wait(Ref, Index, VnodePid) ->
         {Ref, Reply} ->
             erlang:demonitor(MonRef),
             Reply;
-        {'DOWN',MonRef,process,VnodePid,normal} ->
+        {'DOWN', MonRef, process, VnodePid, Reason} when (Reason =:= normal); (Reason =:= noproc) ->
             %% the vnode likely just shut down after completing handoff
             {ok, Ring} = riak_core_ring_manager:get_my_ring(),
             Next = case riak_core_ring:next_owner(Ring, Index) of


### PR DESCRIPTION
Previously, queue_work_wait would handle a normal exit from a vnode which was handing off, but would not actually detect the case that the vnode exited _before_ the erlang:monitor call (which then sends a 'DOWN' message with `noproc` as its reason instead of `normal`. Add handling of the `noproc` case and forward the message as well.
