### PR TITLE
Fix dialyzer warnings in riak_pipe_cinfo [JIRA: RIAK-3245]

### DIFF
--- a/src/riak_pipe_cinfo.erl
+++ b/src/riak_pipe_cinfo.erl
@@ -58,11 +58,11 @@ pipeline(C, Pipe) ->
         {ok, Fits} ->
             cluster_info:format(C, " - ~p fittings: ~b alive~n",
                                 [Pipe, length(Fits)]),
-            [ fitting(C, Fit) || Fit <- Fits ];
+            _ = [ fitting(C, Fit) || Fit <- Fits ],
+            ok;
         gone ->
             cluster_info:format(C, " - ~p *gone*~n", [Pipe])
-    end,
-    ok.
+    end.
 
 %% @doc Print information about the given fitting.
 %%      The pid given should be that of the fitting.
@@ -73,11 +73,11 @@ fitting(C, Fit) ->
             %% TODO: add 'name' from details? maybe module/etc. too?
             cluster_info:format(C, "   + ~p worker partitions: ~b~n",
                                 [Fit, length(Workers)]),
-            [ fitting_worker(C, W) || W <- Workers ];
+            _ = [ fitting_worker(C, W) || W <- Workers ],
+            ok;
         gone ->
             cluster_info:format(C, "   + ~p *gone*~n", [Fit])
-    end,
-    ok.
+    end.
 
 %% @doc Print the ring partition index of a vnode doing work for some
 %%      fitting.  The `Worker' should be the index to print.

--- a/src/riak_pipe_fitting.erl
+++ b/src/riak_pipe_fitting.erl
@@ -556,22 +556,15 @@ validate_nval({Mod, Fun}) when is_atom(Mod), is_atom(Fun) ->
     riak_pipe_v:validate_function("nval", 1, {Mod, Fun});
 validate_nval(NVal) ->
     {error, io_lib:format(
-              "expected a positive integer,"
-              " or a function or {Mod, Fun} of arity 1; not a ~p",
-              [riak_pipe_v:type_of(NVal)])}.
+              "expected a positive integer, or a function, or {Mod, Fun} of arity 1; got ~p",
+              [NVal])}.
 
 %% @doc Validate the q_limit parameter.  This must be a positive integer.
 -spec validate_q_limit(term()) -> ok | {error, string()}.
-validate_q_limit(QLimit) when is_integer(QLimit) ->
-    if QLimit > 0 -> ok;
-       true ->
-            {error, io_lib:format(
-                      "expected a positive integer, found ~p", [QLimit])}
-    end;
+validate_q_limit(QLimit) when is_integer(QLimit), QLimit > 0 ->
+    ok;
 validate_q_limit(QLimit) ->
-    {error, io_lib:format(
-              "expected a positive integer, not a ~p",
-              [riak_pipe_v:type_of(QLimit)])}.
+    {error, io_lib:format("expected a positive integer, but got: ~p", [QLimit])}.
 
 %% @doc Coerce a fitting name into a printable string.
 -spec format_name(term()) -> iolist().

--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -23,8 +23,7 @@
 -module(riak_pipe_v).
 
 -export([validate_module/2,
-         validate_function/3,
-         type_of/1]).
+         validate_function/3]).
 
 %% @doc Validate that `Module' is an atom that names a loaded or
 %%      loadable module.  If a module is already loaded under that
@@ -43,8 +42,8 @@ validate_module(Label, Module) when is_atom(Module) ->
                       [Label, Module, Error])}
     end;
 validate_module(Label, Module) ->
-    {error, io_lib:format("~s must be an atom, not a ~p",
-                          [Label, type_of(Module)])}.
+    {error, io_lib:format("~s expected an atom, got: ~p",
+                          [Label, Module])}.
 
 %% @doc Validate that `Fun' is a function of arity `Arity'.
 %%
@@ -80,13 +79,11 @@ validate_function(Label, Arity, Fun) when is_function(Fun) ->
                       Label, Arity, Module, Function)
             end;
         N ->
-            {error, io_lib:format("~s must be of arity ~b, not ~b",
-                                  [Label, Arity, N])}
+            {error, io_lib:format("~s must be of arity ~b, not ~b", [Label, Arity, N])}
     end;
 validate_function(Label, Arity, Fun) ->
-    {error, io_lib:format(
-              "~s must be a function or {Mod, Fun} (arity ~b), not a ~p",
-              [Label, Arity, type_of(Fun)])}.
+    {error, io_lib:format("~s must be a function or {Mod, Fun} (arity ~b), but instead got: ~p",
+                          [Label, Arity, Fun])}.
 
 %% @doc Validate an exported function.  See {@link validate_function/3}.
 -spec validate_exported_function(string(), integer(), atom(), atom()) ->
@@ -106,21 +103,4 @@ validate_exported_function(Label, Arity, Module, Function) ->
         {error,Error} ->
             {error, io_lib:format("invalid module named in ~s function:~n~s",
                                   [Label, Error])}
-    end.
-
-%% @doc Determine the type of a term.  For example:
-%% ```
-%% number = riak_pipe_v:type_of(1).
-%% atom = riak_pipe_v:type_of(a).
-%% pid = riak_pipe_v:type_of(self()).
-%% function = riak_pipe_v:type_of(fun() -> ok end).
-%% '''
--spec type_of(term()) -> pid | reference | list | tuple | atom
-                       | number | binary | function.
-type_of(Term) ->
-    case erl_types:t_from_term(Term) of
-        {c,identifier,[Type|_],_} ->
-            Type; % pid,reference
-        {c,Type,_,_} ->
-            Type  % list,tuple,atom,number,binary,function
     end.

--- a/src/riak_pipe_w_reduce.erl
+++ b/src/riak_pipe_w_reduce.erl
@@ -189,8 +189,7 @@ reduce(Key, InAcc, #state{p=Partition, fd=FittingDetails}) ->
 validate_arg(Fun) when is_function(Fun) ->
     riak_pipe_v:validate_function("arg", 4, Fun);
 validate_arg(Fun) ->
-    {error, io_lib:format("~p requires a function as argument, not a ~p",
-                          [?MODULE, riak_pipe_v:type_of(Fun)])}.
+    {error, io_lib:format("~p requires a function as argument, but got: ~p", [?MODULE, Fun])}.
 
 %% @doc The preferred hashing function.  Chooses a partition based
 %%      on the hash of the `Key'.

--- a/src/riak_pipe_w_tee.erl
+++ b/src/riak_pipe_w_tee.erl
@@ -74,7 +74,5 @@ done(_State) ->
 validate_arg(sink)   -> ok;
 validate_arg(#fitting{}) -> ok;
 validate_arg(Other) ->
-    {error, io_lib:format("~p requires a fitting record,"
-                          " or the atom 'sink'"
-                          " as its argument, not a ~p",
-                          [?MODULE, riak_pipe_v:type_of(Other)])}.
+    {error, io_lib:format("~p requires a fitting record, or the atom 'sink'"
+                          " as its argument, but instead got: ~p", [?MODULE, Other])}.

--- a/src/riak_pipe_w_xform.erl
+++ b/src/riak_pipe_w_xform.erl
@@ -82,5 +82,4 @@ done(_State) ->
 validate_arg(Fun) when is_function(Fun) ->
     riak_pipe_v:validate_function("arg", 3, Fun);
 validate_arg(Fun) ->
-    {error, io_lib:format("~p requires a function as argument, not a ~p",
-                          [?MODULE, riak_pipe_v:type_of(Fun)])}.
+    {error, io_lib:format("~p requires a function as argument, but got: ~p", [?MODULE, Fun])}.


### PR DESCRIPTION
Not sure why nobody ever fixed these before, but without this commit we get two warnings:

```
riak_pipe_cinfo.erl:57: Expression produces a value of type 'ok' | ['ok'], but this value is unmatched
riak_pipe_cinfo.erl:71: Expression produces a value of type 'ok' | ['ok'], but this value is unmatched
```