### PR TITLE
Switch core to develop-2.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,5 +7,5 @@
 {xref_checks, []}.
 {xref_queries, [{"(XC - UC) || (XU - X - B - cluster_info : Mod)", []}]}.
 {deps, [
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.9-225"}}}
+       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
        ]}.


### PR DESCRIPTION
Standardise riak_core reference for develop-2.9