### PR TITLE
Fix OTP26 dialyzer complaints

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "mas-otp26-dialyzer"}}}
+        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}}
        ]}.
 
 {plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "develop"}}}
+        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "mas-otp26-dialyzer"}}}
        ]}.
 
 {plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}}
+        {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "develop"}}}
        ]}.
 
 {plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}]}.

--- a/src/riak_pipe.app.src
+++ b/src/riak_pipe.app.src
@@ -9,8 +9,7 @@
                   sasl,
                   riak_core,
                   cluster_info,
-                  exometer_core,
-                  dialyzer
+                  exometer_core
                  ]},
   {mod, { riak_pipe_app, []}},
   {env, []}

--- a/src/riak_pipe.app.src
+++ b/src/riak_pipe.app.src
@@ -7,7 +7,10 @@
                   kernel,
                   stdlib,
                   sasl,
-                  riak_core
+                  riak_core,
+                  cluster_info,
+                  exometer_core,
+                  dialyzer
                  ]},
   {mod, { riak_pipe_app, []}},
   {env, []}

--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -135,7 +135,7 @@ type_of(Term) ->
             fun({CheckFun, Result}, Acc) ->
                 case Acc of
                     {unidentified, T} ->
-                        case CheckFun(erl_types:t_from_term(T)) of
+                        case CheckFun(T) of
                             true ->
                                 {Result, T};
                             false ->
@@ -145,7 +145,7 @@ type_of(Term) ->
                         Acc
                 end
             end,
-            {unidentified, Term},
+            {unidentified, erl_types:t_from_term(Term)},
             Checkers)).
 
 -ifdef(TEST).

--- a/src/riak_pipe_v.erl
+++ b/src/riak_pipe_v.erl
@@ -119,34 +119,24 @@ validate_exported_function(Label, Arity, Module, Function) ->
     pid | reference | list | tuple | atom | number | binary | function.
 
 -spec type_of(term()) -> checkable_types() | unidentified.
-type_of(Term) ->
-    Checkers =
-        [{fun erl_types:t_is_pid/1, pid},
-            {fun erl_types:t_is_reference/1, reference},
-            {fun erl_types:t_is_list/1, list},
-            {fun erl_types:t_is_tuple/1, tuple},
-            {fun erl_types:t_is_atom/1, atom},
-            {fun erl_types:t_is_number/1, number},
-            {fun erl_types:t_is_binary/1, binary},
-            {fun erl_types:t_is_fun/1, function}],
-    element(
-        1,
-        lists:foldl(
-            fun({CheckFun, Result}, Acc) ->
-                case Acc of
-                    {unidentified, T} ->
-                        case CheckFun(T) of
-                            true ->
-                                {Result, T};
-                            false ->
-                                {unidentified, T}
-                        end;
-                    Acc ->
-                        Acc
-                end
-            end,
-            {unidentified, erl_types:t_from_term(Term)},
-            Checkers)).
+type_of(Pid) when is_pid(Pid) ->
+    pid;
+type_of(Ref) when is_reference(Ref) ->
+    reference;
+type_of(List) when is_list(List) ->
+    list;
+type_of(Tuple) when is_tuple(Tuple) ->
+    tuple;
+type_of(Atom) when is_atom(Atom) ->
+    atom;
+type_of(Number) when is_number(Number) ->
+    number;
+type_of(Binary) when is_binary(Binary) ->
+    binary;
+type_of(Fun) when is_function(Fun) ->
+    function;
+type_of(_Other) ->
+    unidentified.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
Dialyzer not happy about `riak_pipe_v:type_of/1` knowing about opaque structure, and so more convoluted method required.